### PR TITLE
have cromwell run output stderr and stdout upon failing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "colorama>=0.4.6",
     "httpx>=0.28.1",
     "pytest>=8.3.4",
     "sh>=2.1.0",

--- a/tests/cromwelljava/utils.py
+++ b/tests/cromwelljava/utils.py
@@ -1,7 +1,11 @@
+from io import StringIO
 import os
 from pathlib import Path
 
 import sh
+from colorama import Fore, Style, init
+
+init(autoreset=True)
 
 
 class Womtool(object):
@@ -39,6 +43,8 @@ class CromwellJava(object):
     """Cromwell Java class - run Cromwell Java jar"""
 
     def __init__(self):
+        self.stderr = StringIO()
+        self.stdout = StringIO()
         self.cromwell_path = os.getenv("CROMWELL_PATH")
         if not self.cromwell_path:
             raise Exception("failed setting CROMWELL_PATH")
@@ -64,9 +70,14 @@ class CromwellJava(object):
             self.has_options(wdl_path)
             if show_cmd:
                 print(self.cromwell)
-            self.cromwell()
+            self.cromwell(_out=self.stdout, _err=self.stderr)
         except sh.ErrorReturnCode as e:
-            print(f"Command {e.full_cmd} exited with {e.exit_code}")
+            print(Fore.RED + Style.BRIGHT + f"\nCommand {e.full_cmd} exited with {e.exit_code}\n")
+            print(Fore.RED + Style.BRIGHT + f"Dumping cromwell run output\n")
+            print(Fore.YELLOW + Style.BRIGHT + "STDERR output:\n")
+            print(self.stderr.getvalue())
+            print(Fore.YELLOW + Style.BRIGHT + "STDOUT output:\n")
+            print(self.stdout.getvalue())
             return False
 
         return True


### PR DESCRIPTION
To help us debug workflows

to help in general but triggered by #68 - we'll be able to see this output in GH Actions now (and running locally)

Before this PR there was no output from the cromwell run upon error

What it looks like upon run failure

![Screenshot 2025-01-17 at 9 48 13 AM](https://github.com/user-attachments/assets/b283c499-ef8c-4dd2-82cd-42b3ad895859)

