### PR TITLE
Proof hardening

### DIFF
--- a/tests/cromwellapi/cromwell.py
+++ b/tests/cromwellapi/cromwell.py
@@ -6,19 +6,13 @@ from tenacity import (
     wait_exponential,
 )
 
-from utils import TOKEN, past_date, token_check
+from utils import TOKEN, past_date, token_check, before_sleep_message
 
 
 def as_file_object(path=None):
     if not path:
         return None
     return open(path, mode="rb")
-
-
-def my_before_sleep(state):
-    print(
-        f"Retrying in {state.next_action.sleep} seconds, attempt {state.attempt_number}"
-    )
 
 
 def path_as_string(x):
@@ -61,7 +55,7 @@ class CromwellApi(object):
         retry=retry_if_exception_type(httpx.HTTPStatusError),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=4, max=10),
-        before_sleep=my_before_sleep,
+        before_sleep=before_sleep_message,
     )
     def metadata(self, workflow_id, params={}):
         res = httpx.get(
@@ -119,7 +113,7 @@ class CromwellApi(object):
         retry=retry_if_exception_type(httpx.HTTPStatusError),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=4, max=10),
-        before_sleep=my_before_sleep,
+        before_sleep=before_sleep_message,
     )
     def outputs(self, workflow_id):
         res = httpx.get(
@@ -133,7 +127,7 @@ class CromwellApi(object):
         retry=retry_if_exception_type(httpx.HTTPStatusError),
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=1, min=4, max=10),
-        before_sleep=my_before_sleep,
+        before_sleep=before_sleep_message,
     )
     def labels(self, workflow_id):
         res = httpx.get(

--- a/tests/cromwellapi/utils.py
+++ b/tests/cromwellapi/utils.py
@@ -78,3 +78,9 @@ def past_date(days):
     now = datetime.now()
     past_date = now - timedelta(days=days)
     return past_date.strftime("%Y-%m-%d")
+
+
+def before_sleep_message(state):
+    print(
+        f"Retrying in {state.next_action.sleep} seconds, attempt {state.attempt_number}"
+    )


### PR DESCRIPTION
fix #79 

- rename `tenacity` helper function `my_before_sleep` and move it to utils so it can be used in multiple places
- add `tenacity` retries to the 2 class methods that do http requests in `ProofApi` where they retry on either any http status error or a readtimeout error - we've been getting a lot of read timeout errors 
- (This is optional, could leave out if we're not sure) added a decorator to just `ProofApi.status` method because the main (only?) way we use this class right now is through the `ProofAPi.cromwell_url` method that ends up calling `ProofApi.status` twice - so this cache decorator caches the first response, then the very next one uses the cache, then the next does a real http request, etc. - note: from gemini. there's a more probably comprehensive way to do this via https://hishel.com/ but this was a quick fix