### PR TITLE
Run API tests on repository_dispatch

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -8,6 +8,8 @@ on:
       - test-api
   pull_request:
   workflow_dispatch:
+  repository_dispatch:
+    types: [dispatch-event]
 
 jobs:
   api-tests:
@@ -26,6 +28,13 @@ jobs:
 
       - name: Install dependencies
         run: uv sync --all-extras
+
+      - name: Dispatch event information
+        if: ${{ github.event_name == 'repository_dispatch' }}
+        run: |
+          echo PROOF-API SHA: ${{ github.event.client_payload.sha }}
+          echo PROOF-API REF: ${{ github.event.client_payload.ref }}
+          echo PROOF-API PR No.: ${{ github.event.client_payload.pr }}
 
       - name: Run tests
         env:


### PR DESCRIPTION
FredHutch/proof-api#123

receive dispatch event from proof-api - this should get triggered based on the following in proof-api repo:

- any pushes to branch `dev`
- any PRs opened to branch `main`

note that:
- the PR number echo line doesn't work yet, i haven't figured that out yet, maybe someone here knows?
- note that `client_payload` is the json payload key that's in the payload we construct in the post request in the proof api repo

Any thoughts on this? 