### PR TITLE
rewrite cassettes: change workflow name and run on workflow dispatch too

### DIFF
--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   api-tests-rewrite:
-    if: ${{ ! github.event.pull_request.head.repo.fork && github.event_name == 'schedule' }}
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -1,4 +1,4 @@
-name: API Tests
+name: API Tests - Rewrite Cassettes
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
- rename: was in another PR https://github.com/FredHutch/wdl-unit-tests/pull/93 but that one is on hold for some time unknown
- realized that we weren't letting workflow dispatch go through since the if block for the whole job required that it was from cron schedule only