### PR TITLE
New action workflow for checking linting/formatting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,27 +9,28 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 ### Suggesting New Unit Tests
 
 New unit test suggestions are tracked as GitHub issues. When creating a unit test suggestion, please:
-- First check the [issue tracker](https://github.com/FredHutch/wdl-unit-tests/issues) to identify if your issue/proposed unit test is already in development. This avoids duplication and promotes collaborative efforts on problems of common interest. 
+- First check the [issue tracker](https://github.com/FredHutch/wdl-unit-tests/issues) to identify if your issue/proposed unit test is already in development. This avoids duplication and promotes collaborative efforts on problems of common interest.
 - Use a clear and descriptive title
 - Provide a detailed description of what the unit test is actually intending to test?
 - Explain why this additional test would be useful
 
 ### Contributing New Unit Tests
 
-1. Once you have identified a new unit test and would like to contribute towards building this repository, begin by filing an issue in this repository. 
+1. Once you have identified a new unit test and would like to contribute towards building this repository, begin by filing an issue in this repository.
 2. Clone the repo locally and create a branch from `main`. Please name the branch using this convention: "issue#-issue-title"
-3. Create a very specific WDL unit test and make sure to add enough commentary in the code. 
+3. Create a very specific WDL unit test and make sure to add enough commentary in the code.
 4. Ensure your proposed WDL runs locally via `miniwdl run` or `java -jar cromwell-87.jar run`
 5. If you are user of PROOF, please also make sure to test that the WDL unit test runs via PROOF.
     - If your WDL succeeds locally but fails in PROOF, please report the issue in the [proof-api repo](https://github.com/FredHutch/proof-api/issues).
 6. Add the WDL to a subdirectory by the same name, i.e. `coolUnitTest/coolUnitTest.wdl`. If the WDL is expected to fail WOMtool the subdirectory AND the WDL file name must start with `badVal`. If the WDL is expected to fail both WOMtool and a Cromwell run, then the subdirectory AND the WDL file name must start with `badRun`.
 7. Make sure to include an `inputs.json` and `options.json` if required and make sure that any other. input files referenced in `inputs.json` are provided in the same directory.
 8. Add a README to the WDL's subdirectory describing the unit test's functionality and purpose.
-9. Commit and push your proposed changes to GitHub.
-10. Create a pull request describing the updates and identifying the corresponding GitHub issue.
-11. Request a review from a member of the DaSL team (ideally the person requesting the test).
-12. Address all comments/requested changes from these reviews.
-13. Once the PR has been approved and all checks have passed, merge the PR into `main`.
+9. If you make any changes to Python files in `tests/` make sure to run `make lint-check` and `make format-check` and make any changes as suggested by those commands
+10. Commit and push your proposed changes to GitHub.
+11. Create a pull request describing the updates and identifying the corresponding GitHub issue.
+12. Request a review from a member of the DaSL team (ideally the person requesting the test).
+13. Address all comments/requested changes from these reviews.
+14. Once the PR has been approved and all checks have passed, merge the PR into `main`.
 
 ## Style Guidelines
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,28 @@
+name: Ruff
+
+on: [push, pull_request]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      # Include `--output-format=github` to enable automatic inline annotations.
+      - name: Run Ruff linter
+        run: uv run ruff check --output-format=github --select I tests/
+
+      # Include `--output-format=github` to enable automatic inline annotations.
+      - name: Run Ruff formatter
+        run: uv run ruff format --check --output-format=github tests/

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   ruff:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -5,8 +5,6 @@ on: [push, pull_request]
 jobs:
   ruff:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -25,4 +25,4 @@ jobs:
 
       # Include `--output-format=github` to enable automatic inline annotations.
       - name: Run Ruff formatter
-        run: uv run ruff format --check --output-format=github tests/
+        run: uv run ruff format --check tests/

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,11 @@ lint-fix:
 lint-check:
 	uv run ruff check --select I tests/
 
-format:
+format-fix:
 	uv run ruff format tests/
+
+format-check:
+	uv run ruff format --check tests/
 
 check_env_vars:
 	$(call check_defined, PATH_ROOTS, env var for which paths to scrub in vcr cassettes)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Familiarity with two tools will help you run and especially contribute to tests:
 - [pytest][]: a Python test framework. when you run `uv sync` above you'll then have a cli binary `pytest` available
 - [uv][]: a Python package and project manager; manages dependencies, runs tests, etc.
 
+If you make any changes to Python files in `tests/` make sure to run `make lint-check` and `make format-check` and make any changes as suggested by those commands
+
 ### Java
 
 These tests are run on GitHub Actions on each pull request via the `.github/workflows/cromwell-test-run.yml` and `.github/workflows/womtools-validate.yml` workflows.

--- a/tests/cromwellapi/conftest.py
+++ b/tests/cromwellapi/conftest.py
@@ -16,9 +16,7 @@ mocked_submissions = "tests/cromwellapi/mocked_submissions.json"
 def pytest_report_header(config):
     mode = config.getoption("--record-mode", default=None)
     last_mod = cassettes_last_modified("tests/cromwellapi/cassettes")
-    retry_messages_warn = (
-        "" if mode == "rewrite" else "(ignore Retry attempt messages)"
-    )
+    retry_messages_warn = "" if mode == "rewrite" else "(ignore Retry attempt messages)"
     return [
         f"vcr recording mode: {mode} {retry_messages_warn}",
         f"vcr cassettes last recorded approx.: {last_mod}",
@@ -86,6 +84,7 @@ def submit_wdls(recording_mode, cromwell_api):
 
 class EnvironmentVariableError(Exception):
     """Custom error class for a missing environment variable"""
+
     pass
 
 

--- a/tests/cromwellapi/conftest.py
+++ b/tests/cromwellapi/conftest.py
@@ -1,15 +1,14 @@
-import os
 import json
+import os
 from pathlib import Path
 
 import pytest
-
-from mocks import MockProofApi
 from constants import SLEEP_FINAL_STATE
-from utils_cassettes import cassettes_last_modified
 from cromwell import CromwellApi
 from cromwell_final import CromwellApiFinal
+from mocks import MockProofApi
 from proof import ProofApi
+from utils_cassettes import cassettes_last_modified
 
 mocked_submissions = "tests/cromwellapi/mocked_submissions.json"
 

--- a/tests/cromwellapi/constants.py
+++ b/tests/cromwellapi/constants.py
@@ -1,6 +1,5 @@
 import os
 
-
 SLEEP_FINAL_STATE = 5
 PROOF_BASE_URL = "https://proof-api-dev.fredhutch.org"
 TOKEN = os.getenv("PROOF_API_TOKEN_DEV")

--- a/tests/cromwellapi/cromwell.py
+++ b/tests/cromwellapi/cromwell.py
@@ -1,15 +1,14 @@
 from pathlib import Path
 
 import httpx
+from constants import TOKEN
 from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
-
-from constants import TOKEN
-from utils import past_date, token_check, before_sleep_message
+from utils import before_sleep_message, past_date, token_check
 
 
 def as_file_object(path=None):

--- a/tests/cromwellapi/mocks.py
+++ b/tests/cromwellapi/mocks.py
@@ -1,6 +1,7 @@
-import yaml
 from pathlib import Path
 from urllib.parse import urlparse, urlunparse
+
+import yaml
 
 
 class MockProofApi(object):

--- a/tests/cromwellapi/proof.py
+++ b/tests/cromwellapi/proof.py
@@ -1,13 +1,12 @@
 import httpx
+from constants import PROOF_BASE_URL, TOKEN
 from tenacity import (
     retry,
     retry_if_exception_type,
     stop_after_attempt,
     wait_exponential,
 )
-
-from constants import PROOF_BASE_URL, TOKEN
-from utils import token_check, before_sleep_message
+from utils import before_sleep_message, token_check
 
 
 def cache_next_call_only(func):

--- a/tests/cromwellapi/test-abort.py
+++ b/tests/cromwellapi/test-abort.py
@@ -1,6 +1,5 @@
 import pytest
-
-from utils import path_wdl, path_options
+from utils import path_options, path_wdl
 
 wdls = ["helloHostname", "helloDockerHostname"]
 

--- a/tests/cromwellapi/test-call.py
+++ b/tests/cromwellapi/test-call.py
@@ -1,6 +1,6 @@
-import pytest
 from unittest.mock import patch
 
+import pytest
 from utils import metadata_response_keys, workflow_states
 
 params = {"expandSubWorkflows": True}

--- a/tests/cromwellapi/test-failures.py
+++ b/tests/cromwellapi/test-failures.py
@@ -1,10 +1,9 @@
-import time
 import re
-import pytest
+import time
 from unittest.mock import patch
 
+import pytest
 from utils import workflow_states
-
 
 params = {
     "includeKey": [

--- a/tests/cromwellapi/test-labels.py
+++ b/tests/cromwellapi/test-labels.py
@@ -1,8 +1,8 @@
-import pytest
-from unittest.mock import patch
 from pathlib import Path
+from unittest.mock import patch
 
-from utils import path_wdl, path_options
+import pytest
+from utils import path_options, path_wdl
 
 LABELS_FILE_1 = Path("tests/cromwellapi/labels1.json")
 

--- a/tests/cromwellapi/test-metadata.py
+++ b/tests/cromwellapi/test-metadata.py
@@ -1,5 +1,4 @@
 import pytest
-
 from utils import metadata_response_keys, workflow_states
 
 params = {"expandSubWorkflows": False, "excludeKey": "calls"}

--- a/tests/cromwellapi/test-submit.py
+++ b/tests/cromwellapi/test-submit.py
@@ -1,6 +1,5 @@
 import pytest
-
-from utils import path_wdl, path_options
+from utils import path_options, path_wdl
 
 
 @pytest.mark.vcr

--- a/tests/cromwellapi/test-validate.py
+++ b/tests/cromwellapi/test-validate.py
@@ -1,6 +1,5 @@
 import pytest
-
-from utils import path_wdl, path_options
+from utils import path_options, path_wdl
 
 
 @pytest.mark.vcr

--- a/tests/cromwellapi/utils_cassettes.py
+++ b/tests/cromwellapi/utils_cassettes.py
@@ -1,8 +1,9 @@
-import yaml
 import itertools
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+
 import dateparser
+import yaml
 
 
 def list_cassettes(dir):

--- a/tests/cromwelljava/utils.py
+++ b/tests/cromwelljava/utils.py
@@ -72,7 +72,11 @@ class CromwellJava(object):
                 print(self.cromwell)
             self.cromwell(_out=self.stdout, _err=self.stderr)
         except sh.ErrorReturnCode as e:
-            print(Fore.RED + Style.BRIGHT + f"\nCommand {e.full_cmd} exited with {e.exit_code}\n")
+            print(
+                Fore.RED
+                + Style.BRIGHT
+                + f"\nCommand {e.full_cmd} exited with {e.exit_code}\n"
+            )
             print(Fore.RED + Style.BRIGHT + f"Dumping cromwell run output\n")
             print(Fore.YELLOW + Style.BRIGHT + "STDERR output:\n")
             print(self.stderr.getvalue())

--- a/tests/cromwelljava/utils.py
+++ b/tests/cromwelljava/utils.py
@@ -1,5 +1,5 @@
-from io import StringIO
 import os
+from io import StringIO
 from pathlib import Path
 
 import sh


### PR DESCRIPTION
fix #104 

The change to look at here is the new file `.github/workflows/ruff.yml` it has two steps to look at: check and format

The other changes are formatting/checking changes in files based on changes made locally to make these checks pass

- e.g, of check failing https://github.com/FredHutch/wdl-unit-tests/actions/runs/13509982230/job/37748047527#step:6:1 
- e.g., of format failing https://github.com/FredHutch/wdl-unit-tests/actions/runs/13510021080/job/37748156105#step:7:1 
- when the above two succeed the action exits with code 0 (Success) and the next step begins
- this action file doesn't make any changes, jus flags stuff to be fixed