### PR TITLE
Adding missing options json's to existing WDL unit tests

### DIFF
--- a/WildcardsandConditions/options.json
+++ b/WildcardsandConditions/options.json
@@ -1,0 +1,5 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": false,
+    "read_from_cache": false
+}

--- a/badRunParseBatchFile/options.json
+++ b/badRunParseBatchFile/options.json
@@ -1,0 +1,5 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": false,
+    "read_from_cache": false
+}

--- a/badValMissingValue/options.json
+++ b/badValMissingValue/options.json
@@ -1,0 +1,5 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": false,
+    "read_from_cache": false
+}

--- a/basicTaskExecution/options.json
+++ b/basicTaskExecution/options.json
@@ -1,0 +1,5 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": false,
+    "read_from_cache": false
+}

--- a/testFileoperations/options.json
+++ b/testFileoperations/options.json
@@ -1,0 +1,5 @@
+{
+    "workflow_failure_mode": "ContinueWhilePossible",
+    "write_to_cache": false,
+    "read_from_cache": false
+}


### PR DESCRIPTION
## Description
- Some of our earlier WDL unit tests are missing `options.json` files.
- These are important to explicitly define that caching should not be used.

## Related Issues
- Fixes #123 

## Testing
- Affected unit tests still pass GitHub Action test runs