### PR TITLE
make commands for droppping into ipython or python shells

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,11 @@ test_api_cached: check_env_vars
 
 test_api_rewrite: check_env_vars
 	op run -- uv run pytest --color=yes --record-mode=rewrite --verbose -s tests/cromwellapi/
+
+ipython: check_env_vars
+	cd tests/cromwellapi/ && \
+	op run --no-masking -- uv run --with rich --with ipython python -m IPython
+
+py: check_env_vars
+	cd tests/cromwellapi/ && \
+	op run --no-masking -- uv run python


### PR DESCRIPTION
fix #141

can you two test this out on your machines? try both commands and check if using 1password creds is working, e.g., 

```python 
from proof import ProofApi
from cromwell import CromwellApi
proof_api = ProofApi()
cromwell_url = proof_api.cromwell_url()
api = CromwellApi(url=cromwell_url)
api.version()
```

- Does python 3.13 come with both cmds?
- When you exit each of ipython or python your back in the root of the directory?

@tefirman a bit more context: 
- This PR was opened because of #141 - see https://github.com/FredHutch/wdl-unit-tests/issues/141#issue-2908517905 
- The `--no-masking` is needed because its inverse (presence of masking) is the cause of the problem. Masking basically hides any printing of secrets on the command line, but I think it's okay to turn this off as there's no fix for it for now, and there's a limited set of us working on it
- We don't need to activate a virtual env because `uv run` does that for us behind the scenes
- The `--with rich --with ipython` part installs `rich` and `ipython` just for that session of using ipython - we don't need those for the project so not adding them to the dependencies