### PR TITLE
Dev tooling change?

### DIFF
--- a/tests/cromwellapi/cromwell.py
+++ b/tests/cromwellapi/cromwell.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import httpx
 from constants import TOKEN
 from tenacity import (
@@ -8,7 +6,12 @@ from tenacity import (
     stop_after_attempt,
     wait_exponential,
 )
-from utils import before_sleep_message, past_date, token_check
+from utils import (
+    before_sleep_message,
+    find_project_root,
+    past_date,
+    token_check,
+)
 
 
 def as_file_object(path=None):
@@ -52,7 +55,7 @@ class CromwellApi(object):
         )
         res.raise_for_status()
         data = res.json()
-        data["path"] = str(wdl_path.relative_to(Path.cwd()))
+        data["path"] = str(wdl_path.relative_to(find_project_root()))
         return data
 
     @retry(

--- a/tests/cromwellapi/utils.py
+++ b/tests/cromwellapi/utils.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -122,3 +123,24 @@ def before_sleep_message(state):
     print(
         f"Retrying in {state.next_action.sleep} seconds, attempt {state.attempt_number}"
     )
+
+
+def find_project_root(marker_file="pyproject.toml"):
+    """
+    A hack to avoid using __file__ as that does not work when using a
+    python repl (python or ipython)
+    """
+    current_dir = os.getcwd()
+
+    while True:
+        if os.path.exists(os.path.join(current_dir, marker_file)):
+            return current_dir
+
+        parent_dir = os.path.dirname(current_dir)
+
+        if parent_dir == current_dir:
+            break
+
+        current_dir = parent_dir
+
+    return current_dir

--- a/tests/cromwellapi/utils_dev.py
+++ b/tests/cromwellapi/utils_dev.py
@@ -1,0 +1,48 @@
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+from cromwell import CromwellApi
+from proof import ProofApi
+from utils import find_project_root
+
+
+@lru_cache(maxsize=None)
+def capi():
+    """Create a CromwellApi instance using the ProofApi
+
+    Cached so that we don't have to connect w/ ProofApi again
+    """
+    proof_api = ProofApi()
+    cromwell_url = proof_api.cromwell_url()
+    return CromwellApi(url=cromwell_url)
+
+
+def submit_workflow(wdl_name):
+    """Submit a workflow to Cromwell
+
+    Args:
+        wdl_name (str): The folder name of the workflow to submit
+
+    Examples:
+      from utils_dev import submit_workflow
+      submit_workflow("helloHostname")
+      # can also run from cli like this:
+      # op run -- uv run tests/cromwellapi/utils_dev.py emptyGlobTest
+    """
+    base = find_project_root()
+    wdl_path = Path(f"{str(base)}/{wdl_name}/{wdl_name}.wdl")
+    inputs_path = wdl_path.parent / "inputs.json"
+    inputs_path = inputs_path if inputs_path.exists() else None
+    opts_path = wdl_path.parent / "options.json"
+    opts_path = opts_path if opts_path.exists() else None
+    cromwell_api = capi()
+    res = cromwell_api.submit_workflow(
+        wdl_path=wdl_path, inputs=inputs_path, options=opts_path
+    )
+    return res
+
+
+if __name__ == "__main__":
+    x = str(sys.argv[1])
+    print(submit_workflow(x))


### PR DESCRIPTION
- new function `submit_workflow` for dev work on this repo. i've found it painful to get a workflow submitted (without using the proof app, which I dont have open these days) for testing purposes when using a python repl. here's a little fxn to do that. and you can run it from cli like `op run -- uv run tests/cromwellapi/utils_dev.py emptyGlobTest`
- new helper function `find_project_root` to avoid `__file__` to make repl usage work. `__file__` works fine if running these tests/etc not interactively, but once you're in a python repl things don't work because of `__file__`. 

if you can please try and let me know if it works