### PR TITLE
Adding Cromwell Config File for GitHub Action Test Run

### DIFF
--- a/cromwell.conf
+++ b/cromwell.conf
@@ -1,0 +1,65 @@
+include required(classpath("application"))
+
+backend {
+  default = "LocalExample"
+  providers {
+    LocalExample {
+      actor-factory = "cromwell.backend.impl.sfs.config.ConfigBackendLifecycleActorFactory"
+      config {
+        job-id-regex = "(\\d+)"
+        
+        runtime-attributes = """
+          Int cpu = 1
+          Int memory_mb = 2000
+          String? docker
+        """
+
+        submit = """
+          echo "1" # Echo a dummy job ID
+          ${job_shell} ${script}
+        """
+        
+        submit-docker = """
+          echo "1" # Echo a dummy job ID
+          docker run \
+            --rm \
+            -v ${cwd}:${docker_cwd} \
+            -w ${docker_cwd} \
+            ${docker} \
+            /bin/bash ${docker_script}
+        """
+
+        # File system settings
+        filesystem {
+          local {
+            localization: [
+              "hard-link", "soft-link", "copy"
+            ]
+          }
+        }
+
+        # Docker configuration
+        docker {
+          hash-lookup {
+            enabled = false
+          }
+        }
+      }
+    }
+  }
+}
+
+call-caching {
+  enabled = true
+  invalidate-bad-cache-results = true
+}
+
+database {
+  profile = "slick.jdbc.HsqldbProfile$"
+  db {
+    driver = "org.hsqldb.jdbcDriver"
+    url = "jdbc:hsqldb:file:cromwell-cache-db;shutdown=false;hsqldb.tx=mvcc"
+    connectionTimeout = 120000
+    numThreads = 1
+  }
+}

--- a/tests/cromwelljava/utils.py
+++ b/tests/cromwelljava/utils.py
@@ -48,7 +48,9 @@ class CromwellJava(object):
         self.cromwell_path = os.getenv("CROMWELL_PATH")
         if not self.cromwell_path:
             raise Exception("failed setting CROMWELL_PATH")
-        self.cromwell = sh.Command("java").bake("-jar", self.cromwell_path)
+        self.cromwell = sh.Command("java").bake(
+            "-jar", "-Dconfig.file=cromwell.conf", self.cromwell_path
+        )
 
     def has_inputs(self, wdl_path):
         path = Path(f"{wdl_path}/inputs.json")


### PR DESCRIPTION
## Description
- Explicitly defines the Cromwell configuration to be used in `tests/cromwelljava/test-run.py`
- Enables a more direct comparison/distinction between Cromwell execution and PROOF execution.
- Also enables the possibility of call-caching during GitHub Action test runs

# Related Issues
- Fixes #154

# Testing
- Unit tests below complete successfully.
- Tested call-caching functionality with this config locally, works as expected.