### PR TITLE
Architecture docs and docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ See our [CONTRIBUTING.md](.github/CONTRIBUTING.md) for exact details on how to c
 
 ## Tests
 
+> [!TIP]
+> [See the architecture doc][docs/architecture.md] to better understand the design of this test suite.
+
 There are two sets of tests for running WDLs against Cromwell using Python:
 
 - `tests/cromwelljava`: Runs WDLs on Cromwell using a local copy of `cromwell-<version>.jar` and `womtool-<version>.jar`. See "Java" below for details.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See our [CONTRIBUTING.md](.github/CONTRIBUTING.md) for exact details on how to c
 ## Tests
 
 > [!TIP]
-> [See the architecture doc](docs/architecture.md) to better understand the design of this test suite.
+> See the [architecture doc](docs/architecture.md) to better understand the design of this test suite.
 
 There are two sets of tests for running WDLs against Cromwell using Python:
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See our [CONTRIBUTING.md](.github/CONTRIBUTING.md) for exact details on how to c
 ## Tests
 
 > [!TIP]
-> [See the architecture doc][docs/architecture.md] to better understand the design of this test suite.
+> [See the architecture doc](docs/architecture.md) to better understand the design of this test suite.
 
 There are two sets of tests for running WDLs against Cromwell using Python:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# wdl-unit-tests docs
+
+- [Architecture](architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,8 @@ tests/cromwellapi
 - `mocked_submissions.json`: metadata stored for when we run vcr using cached cassettes
 - `test-*.py`:  all tests that pytest runs
 
+Tests within all `test-*.py` files have their own documentation that lives with the test code - if you're curious what those tests do read their docstrings; if they need more docs please open an issue or PR.
+
 ## How code flows together
 
 ```mermaid

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,83 @@
+# Architecture
+
+## File Structure
+
+There's a few files for managing Python and the dependencies we use:
+
+```
+├── Makefile
+├── pyproject.toml
+├── pytest.ini
+├── .python-version
+├── .gitignore
+└── uv.lock
+```
+
+- `Makefile`: make commands for running tests, formatting code, etc.
+- `pyproject.toml`: details for managing the project, mostly just dependencies
+- `pytest.ini`: pytest configuration
+- `.python-version`: importantly tells `uv` what version of Python to use
+- `.gitignore`: important to make sure we're not commiting lots of dot and python cache files, etc.
+- `uv.lock`: lock file for uv to manage dependencies. we use the tool [uv](https://docs.astral.sh/uv/) to manage the python code
+
+At the highest level tests are grouped by what they test against
+
+```
+tests
+├── cromwellapi
+└── cromwelljava
+```
+
+- `cromwellapi` : Run tests against the PROOF & Cromwell APIs running on Fred Hutch clusters
+- `cromwelljava`: Run tests against a locally running java cromwell.jar file  (whether that be your machine or GH Actions)
+
+Within `cromwelljava`
+
+```
+tests/cromwelljava
+├── conftest.py
+├── test-run.py
+├── test-validate.py
+└── utils.py
+```
+
+- `conftest.py` has a few fixtures used in tests
+- `test-run.py`: runs `cromwell run` on all wdls
+- `test-validate.py`:  runs `womtool validate` on all wdls
+- `utils.py`: classes `Womtool` and `CromwellJava` for handling of running wdls against the java jar's
+
+Within `cromwellapi`
+
+```
+tests/cromwellapi
+├── cassettes
+├── conftest.py
+├── constants.py / mocks.py / utils.py / utils_cassettes.py / utils_dev.py
+├── cromwell.py
+├── cromwell_final.py
+├── proof.py
+├── labels1.json / mocked_submissions.json
+├── test-*.py # all files that start with test-
+```
+
+- `cassettes`: directory with vcr "cassettes", stored/cached http request/response files so that we can save time running tests
+- `conftest.py`: helper functions, fixtures for tests, vcr configuration (including filtering out sensitive information from cassettes), modifications to pytest header
+- `constants.py` / `mocks.py` / `utils.py` / `utils_cassettes.py`: helpers
+- `cromwell.py`: class to manage all normal interactions with the Cromwell API
+- `cromwell_final.py`: class to manage interactions with the Cromwell API. specifically to fetch final state/status of workflow runs. only used for the `/metadata` route for now
+- `proof.py`: class to manage interactions with the Proof API
+- `labels1.json`: used in `/labels` Cromwell route as it expects a file uploaded that defines label options
+- `mocked_submissions.json`: metadata stored for when we run vcr using cached cassettes
+- `test-*.py`:  all tests that pytest runs
+
+## How code flows together
+
+```mermaid
+flowchart TD
+    A[Proof API<br>proof.py] -->|Imported| B(conftest.py)
+    AA[Cromwell API<br>cromwell.py] -->|Imported| B(conftest.py)
+    A[Proof API<br>proof.py] --> |Get Cromwell URL| AA[Cromwell API<br>cromwell.py]
+    B -->|fixture: cromwell_api| D[test-abort.py]
+    B -->|fixtures: cromwell_api, submit_wdls, recording_mode| E[test-call.py]
+    B -->|fixtures ...| F[fa:fa-vial-circle-check etc.]
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,8 @@ tests
 - `cromwellapi` : Run tests against the PROOF & Cromwell APIs running on Fred Hutch clusters
 - `cromwelljava`: Run tests against a locally running java cromwell.jar file  (whether that be your machine or GH Actions)
 
+If a WDL unit test fails both `cromwelljava` and `cromwellapi` pytests, either Cromwell's underlying functionality has changed or something is wrong with the WDL itself. If a WDL unit test succeeds in `cromwelljava` but fails in `cromwellapi`, this is a PROOF-specific issue that will need to be addressed by our development team at Fred Hutch (OCDO/SciComp).
+
 Within `cromwelljava`
 
 ```

--- a/tests/cromwellapi/cassettes/test-validate/test_validate_good_wdl[globSymlink.wdl].yaml
+++ b/tests/cromwellapi/cassettes/test-validate/test_validate_good_wdl[globSymlink.wdl].yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: "--a98baf38534eda5c36d3d0b376fe2151\r\nContent-Disposition: form-data; name=\"workflowSource\";
+      filename=\"globSymlink.wdl\"\r\nContent-Type: application/octet-stream\r\n\r\nversion
+      1.0\n\nworkflow globSymlink {\n    call create_nested_files\n    output {\n
+      \       Array[File] matched_files = flatten([create_nested_files.matched_files_top,
+      create_nested_files.matched_files_nested])\n        Array[File] symlink_matches
+      = create_nested_files.matched_symlinks\n    }\n}\n\ntask create_nested_files
+      {\n    command <<<\n        mkdir -p subdir/nested\n        echo \"Hello\" >
+      subdir/nested/file1.txt\n        echo \"World\" > subdir/file2.txt\n\n        #
+      Create symlinks\n        mkdir -p symlinks\n        ln -s ../subdir/nested/file1.txt
+      symlinks/link_to_file1.txt\n        ln -s ../subdir/file2.txt symlinks/link_to_file2.txt\n
+      \   >>>\n    output {\n        Array[File] matched_files_top = glob(\"subdir/*.txt\")\n
+      \       Array[File] matched_files_nested = glob(\"subdir/**/*.txt\")\n        Array[File]
+      matched_symlinks = glob(\"symlinks/*.txt\")\n    }\n}\n\r\n--a98baf38534eda5c36d3d0b376fe2151--\r\n"
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1052'
+      content-type:
+      - multipart/form-data; boundary=a98baf38534eda5c36d3d0b376fe2151
+      host:
+      - gizmok29.fhcrc.org:41041
+      user-agent:
+      - python-httpx/0.28.1
+    method: POST
+    uri: https://gizmok29.fhcrc.org:41041/api/womtool/v1/describe
+  response:
+    body:
+      string: '{"valid":true,"errors":[],"validWorkflow":true,"name":"globSymlink","inputs":[],"outputs":[{"name":"matched_files","valueType":{"typeName":"Array","arrayType":{"typeName":"File"},"nonEmpty":false},"typeDisplayName":"Array[File]"},{"name":"symlink_matches","valueType":{"typeName":"Array","arrayType":{"typeName":"File"},"nonEmpty":false},"typeDisplayName":"Array[File]"}],"images":[],"submittedDescriptorType":{"descriptorType":"WDL","descriptorTypeVersion":"1.0"},"importedDescriptorTypes":[],"meta":{},"parameterMeta":{},"isRunnableWorkflow":true}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '549'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 02 Apr 2025 18:21:00 GMT
+      Server:
+      - nginx/1.25.3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cromwellapi/test-abort.py
+++ b/tests/cromwellapi/test-abort.py
@@ -7,7 +7,11 @@ wdls = ["helloHostname", "helloDockerHostname"]
 @pytest.mark.vcr
 @pytest.mark.parametrize("wdl", wdls)
 def test_abort(cromwell_api, wdl):
-    """Checking that abort works"""
+    """
+    Checking that abort works
+
+    Cromwell abort route (/api/workflows/v1/{workflow_id}/abort)
+    """
     workflow = cromwell_api.submit_workflow(
         wdl_path=path_wdl(wdl), options=path_options(wdl)
     )

--- a/tests/cromwellapi/test-abort.py
+++ b/tests/cromwellapi/test-abort.py
@@ -11,6 +11,10 @@ def test_abort(cromwell_api, wdl):
     Checking that abort works
 
     Cromwell abort route (/api/workflows/v1/{workflow_id}/abort)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
+        wdl (str): name of the WDL unit test to submit and subsequently abort
     """
     workflow = cromwell_api.submit_workflow(
         wdl_path=path_wdl(wdl), options=path_options(wdl)

--- a/tests/cromwellapi/test-call.py
+++ b/tests/cromwellapi/test-call.py
@@ -12,6 +12,11 @@ def test_call_initial(cromwell_api, submit_wdls, recording_mode):
     Getting workflow metadata with expandSubWorkflows:true works | initial state
 
     Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
+        submit_wdls: pytest fixture containing details about WDL submissions to PROOF (defined in conftest.py)
+        recording_mode (str): string indicating if the cassettes are getting rewritten or not
     """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:
@@ -38,6 +43,10 @@ def test_call_final(cromwell_api_final, submit_wdls):
     Getting workflow metadata with expandSubWorkflows:true works | final state
 
     Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+
+    Args:
+        cromwell_api_final (CromwellApiFinal): Cromwell server being used to check the status of WDL unit tests (class defined in cromwell_final.py)
+        submit_wdls: pytest fixture containing details about WDL submissions to PROOF (defined in conftest.py)
     """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:

--- a/tests/cromwellapi/test-call.py
+++ b/tests/cromwellapi/test-call.py
@@ -8,7 +8,11 @@ params = {"expandSubWorkflows": True}
 
 @pytest.mark.vcr
 def test_call_initial(cromwell_api, submit_wdls, recording_mode):
-    """Getting workflow metadata with expandSubWorkflows:true works | initial state"""
+    """
+    Getting workflow metadata with expandSubWorkflows:true works | initial state
+
+    Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+    """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:
         if recording_mode != "rewrite":
@@ -30,7 +34,11 @@ def test_call_initial(cromwell_api, submit_wdls, recording_mode):
 
 @pytest.mark.vcr
 def test_call_final(cromwell_api_final, submit_wdls):
-    """Getting workflow metadata with expandSubWorkflows:true works | final state"""
+    """
+    Getting workflow metadata with expandSubWorkflows:true works | final state
+
+    Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+    """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:
         res = cromwell_api_final.metadata(workflow_id=x, params=params)

--- a/tests/cromwellapi/test-failures.py
+++ b/tests/cromwellapi/test-failures.py
@@ -18,6 +18,11 @@ def test_failures_initial(cromwell_api, submit_wdls, recording_mode):
     Checking for failures works for initial state
 
     Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
+        submit_wdls: pytest fixture containing details about WDL submissions to PROOF (defined in conftest.py)
+        recording_mode (str): string indicating if the cassettes are getting rewritten or not
     """
     fail = list(filter(lambda x: x["path"].startswith("bad"), submit_wdls))
     for job in fail:
@@ -50,6 +55,10 @@ def test_failures_final(cromwell_api_final, submit_wdls):
     Checking for failures works for final state
 
     Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+
+    Args:
+        cromwell_api_final (CromwellApiFinal): Cromwell server being used to check the status of WDL unit tests (class defined in cromwell_final.py)
+        submit_wdls: pytest fixture containing details about WDL submissions to PROOF (defined in conftest.py)
     """
     fail = list(filter(lambda x: x["path"].startswith("bad"), submit_wdls))
     fail_check = {

--- a/tests/cromwellapi/test-failures.py
+++ b/tests/cromwellapi/test-failures.py
@@ -14,7 +14,11 @@ params = {
 
 @pytest.mark.vcr
 def test_failures_initial(cromwell_api, submit_wdls, recording_mode):
-    """Checking for failures works for initial state"""
+    """
+    Checking for failures works for initial state
+
+    Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+    """
     fail = list(filter(lambda x: x["path"].startswith("bad"), submit_wdls))
     for job in fail:
         if recording_mode != "rewrite":
@@ -42,7 +46,11 @@ def test_failures_initial(cromwell_api, submit_wdls, recording_mode):
 
 @pytest.mark.vcr
 def test_failures_final(cromwell_api_final, submit_wdls):
-    """Checking for failures works for final state"""
+    """
+    Checking for failures works for final state
+
+    Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+    """
     fail = list(filter(lambda x: x["path"].startswith("bad"), submit_wdls))
     fail_check = {
         "badRunParseBatchFile": "Required workflow input 'parseBatchFile.batchFile' not specified",

--- a/tests/cromwellapi/test-labels.py
+++ b/tests/cromwellapi/test-labels.py
@@ -9,7 +9,11 @@ LABELS_FILE_1 = Path("tests/cromwellapi/labels1.json")
 
 @pytest.mark.vcr
 def test_labels(cromwell_api, recording_mode):
-    """Getting workflow labels works"""
+    """
+    Getting workflow labels works
+
+    Cromwell labels route (/api/workflows/v1/{workflow_id}/labels)
+    """
     job = cromwell_api.submit_workflow(
         wdl_path=path_wdl("helloHostname"),
         labels=LABELS_FILE_1,
@@ -34,7 +38,11 @@ def test_labels(cromwell_api, recording_mode):
 
 @pytest.mark.vcr
 def test_labels_no_labels(cromwell_api, recording_mode):
-    """Workflow labels are empty except for workflow id when no labels submitted"""
+    """
+    Workflow labels are empty except for workflow id when no labels submitted
+
+    Cromwell labels route (/api/workflows/v1/{workflow_id}/labels)
+    """
     job = cromwell_api.submit_workflow(
         wdl_path=path_wdl("helloHostname"),
         options=path_options("helloHostname"),

--- a/tests/cromwellapi/test-labels.py
+++ b/tests/cromwellapi/test-labels.py
@@ -13,6 +13,10 @@ def test_labels(cromwell_api, recording_mode):
     Getting workflow labels works
 
     Cromwell labels route (/api/workflows/v1/{workflow_id}/labels)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
+        recording_mode (str): string indicating if the cassettes are getting rewritten or not
     """
     job = cromwell_api.submit_workflow(
         wdl_path=path_wdl("helloHostname"),
@@ -42,6 +46,10 @@ def test_labels_no_labels(cromwell_api, recording_mode):
     Workflow labels are empty except for workflow id when no labels submitted
 
     Cromwell labels route (/api/workflows/v1/{workflow_id}/labels)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
+        recording_mode (str): string indicating if the cassettes are getting rewritten or not
     """
     job = cromwell_api.submit_workflow(
         wdl_path=path_wdl("helloHostname"),

--- a/tests/cromwellapi/test-metadata.py
+++ b/tests/cromwellapi/test-metadata.py
@@ -10,6 +10,10 @@ def test_metadata_initial(cromwell_api, submit_wdls):
     Getting workflow metadata works - Initial states
 
     Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
+        recording_mode (str): string indicating if the cassettes are getting rewritten or not
     """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:
@@ -26,6 +30,10 @@ def test_metadata_final(cromwell_api_final, submit_wdls):
     Getting workflow metadata works - Final states
 
     Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+
+    Args:
+        cromwell_api_final (CromwellApiFinal): Cromwell server being used to check the status of WDL unit tests (class defined in cromwell_final.py)
+        submit_wdls: pytest fixture containing details about WDL submissions to PROOF (defined in conftest.py)
     """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:

--- a/tests/cromwellapi/test-metadata.py
+++ b/tests/cromwellapi/test-metadata.py
@@ -6,7 +6,11 @@ params = {"expandSubWorkflows": False, "excludeKey": "calls"}
 
 @pytest.mark.vcr
 def test_metadata_initial(cromwell_api, submit_wdls):
-    """Getting workflow metadata works - Initial states"""
+    """
+    Getting workflow metadata works - Initial states
+
+    Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+    """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:
         res = cromwell_api.metadata(workflow_id=x, params=params)
@@ -18,7 +22,11 @@ def test_metadata_initial(cromwell_api, submit_wdls):
 
 @pytest.mark.vcr
 def test_metadata_final(cromwell_api_final, submit_wdls):
-    """Getting workflow metadata works - Final states"""
+    """
+    Getting workflow metadata works - Final states
+
+    Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+    """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:
         res = cromwell_api_final.metadata(workflow_id=x, params=params)

--- a/tests/cromwellapi/test-outputs.py
+++ b/tests/cromwellapi/test-outputs.py
@@ -3,7 +3,11 @@ import pytest
 
 @pytest.mark.vcr
 def test_outputs(cromwell_api, submit_wdls):
-    """Getting workflow outputs works"""
+    """
+    Getting workflow outputs works
+
+    Cromwell outputs route (/api/workflows/v1/{workflow_id}/outputs)
+    """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:
         res = cromwell_api.outputs(x)

--- a/tests/cromwellapi/test-outputs.py
+++ b/tests/cromwellapi/test-outputs.py
@@ -7,6 +7,10 @@ def test_outputs(cromwell_api, submit_wdls):
     Getting workflow outputs works
 
     Cromwell outputs route (/api/workflows/v1/{workflow_id}/outputs)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
+        recording_mode (str): string indicating if the cassettes are getting rewritten or not
     """
     ids = [wf["id"] for wf in submit_wdls]
     for x in ids:

--- a/tests/cromwellapi/test-search.py
+++ b/tests/cromwellapi/test-search.py
@@ -27,7 +27,11 @@ VCR_SEARCH_CONFIG = {
 
 @pytest.mark.vcr(**VCR_SEARCH_CONFIG)
 def test_search_no_results(cromwell_api):
-    """Checking that search works with no results"""
+    """
+    Checking that search works with no results
+
+    Cromwell query route (/api/workflows/v1/query)
+    """
     out = cromwell_api.search(days=-2)
     # There should not be any results for a query for jobs
     # started in the future
@@ -37,7 +41,11 @@ def test_search_no_results(cromwell_api):
 
 @pytest.mark.vcr(**VCR_SEARCH_CONFIG)
 def test_search_results(cromwell_api):
-    """Checking that search works when there MIGHT be results"""
+    """
+    Checking that search works when there MIGHT be results
+
+    Cromwell query route (/api/workflows/v1/query)
+    """
     out = cromwell_api.search(days=1)
     # There may or may not be results, we can't gaurantee it
     if out["totalResultsCount"] == 0:

--- a/tests/cromwellapi/test-search.py
+++ b/tests/cromwellapi/test-search.py
@@ -31,6 +31,9 @@ def test_search_no_results(cromwell_api):
     Checking that search works with no results
 
     Cromwell query route (/api/workflows/v1/query)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to search for WDL unit tests (class defined in cromwell.py)
     """
     out = cromwell_api.search(days=-2)
     # There should not be any results for a query for jobs
@@ -45,6 +48,9 @@ def test_search_results(cromwell_api):
     Checking that search works when there MIGHT be results
 
     Cromwell query route (/api/workflows/v1/query)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to search for WDL unit tests (class defined in cromwell.py)
     """
     out = cromwell_api.search(days=1)
     # There may or may not be results, we can't gaurantee it

--- a/tests/cromwellapi/test-submit.py
+++ b/tests/cromwellapi/test-submit.py
@@ -8,6 +8,9 @@ def test_submit_works(cromwell_api):
     Submitting a WDL file works
 
     Cromwell submission route (/api/workflows/v1)
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
     """
     res = cromwell_api.submit_workflow(
         wdl_path=path_wdl("helloHostname"),

--- a/tests/cromwellapi/test-submit.py
+++ b/tests/cromwellapi/test-submit.py
@@ -4,7 +4,11 @@ from utils import path_options, path_wdl
 
 @pytest.mark.vcr
 def test_submit_works(cromwell_api):
-    """Submitting a WDL file works"""
+    """
+    Submitting a WDL file works
+
+    Cromwell submission route (/api/workflows/v1)
+    """
     res = cromwell_api.submit_workflow(
         wdl_path=path_wdl("helloHostname"),
         options=path_options("helloHostname"),

--- a/tests/cromwellapi/test-successes.py
+++ b/tests/cromwellapi/test-successes.py
@@ -19,6 +19,8 @@ def test_successes_initial(cromwell_api, submit_wdls, recording_mode):
     Ensures that each WDL unit test got submitted successfully with the
     exception of WDL's that are expected to fail (name starts with "bad")
 
+    Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
+
     Args:
         cromwell_api (CromwellApi): PROOF server being used to submit WDL unit tests (class defined in cromwell.py)
         submit_wdls: pytest fixture containing details about WDL submissions to PROOF (defined in conftest.py)
@@ -56,6 +58,8 @@ def test_successes_final(cromwell_api_final, submit_wdls):
     """
     Ensures that each WDL unit test executes successfully with the
     exception of WDL's that are expected to fail (name starts with "bad")
+
+    Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
 
     Args:
         cromwell_api (CromwellApi): PROOF server being used to execute WDL unit tests (class defined in cromwell.py)

--- a/tests/cromwellapi/test-successes.py
+++ b/tests/cromwellapi/test-successes.py
@@ -22,7 +22,7 @@ def test_successes_initial(cromwell_api, submit_wdls, recording_mode):
     Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
 
     Args:
-        cromwell_api (CromwellApi): PROOF server being used to submit WDL unit tests (class defined in cromwell.py)
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
         submit_wdls: pytest fixture containing details about WDL submissions to PROOF (defined in conftest.py)
         recording_mode (str): string indicating if the cassettes are getting rewritten or not
     """
@@ -62,7 +62,7 @@ def test_successes_final(cromwell_api_final, submit_wdls):
     Cromwell metadata route (/api/workflows/v1/{workflow_id}/metadata)
 
     Args:
-        cromwell_api (CromwellApi): PROOF server being used to execute WDL unit tests (class defined in cromwell.py)
+        cromwell_api (CromwellApi): Cromwell server being used to execute WDL unit tests (class defined in cromwell.py)
         submit_wdls: pytest fixture containing details about WDL submissions to PROOF (defined in conftest.py)
     """
     succeed = list(

--- a/tests/cromwellapi/test-validate.py
+++ b/tests/cromwellapi/test-validate.py
@@ -14,6 +14,8 @@ def test_validate_good_wdl(cromwell_api, wdl_path):
     Parametrized pytest used to ensure that each WDL unit test passes validation
     with the exception of WDL's that are expected to fail (name starts with "badVal")
 
+    Cromwell validate route (/api/womtool/v1/describe)
+
     Args:
         cromwell_api (CromwellApi): PROOF server being used to validate WDL unit tests (class defined in cromwell.py)
         wdl_path (PosixPath): location of the WDL script to validate via PROOF
@@ -32,6 +34,8 @@ def test_validate_bad_wdl(cromwell_api, wdl_path):
     """
     Parametrized pytest used to ensure that all WDL unit tests that are expected to fail validation
     (name starts with "badVal") actually fail validation via WOMtool.
+
+    Cromwell validate route (/api/womtool/v1/describe)
 
     Args:
         cromwell_api (CromwellApi): PROOF server being used to validate WDL unit tests (class defined in cromwell.py)

--- a/tests/cromwellapi/test-validate.py
+++ b/tests/cromwellapi/test-validate.py
@@ -17,8 +17,8 @@ def test_validate_good_wdl(cromwell_api, wdl_path):
     Cromwell validate route (/api/womtool/v1/describe)
 
     Args:
-        cromwell_api (CromwellApi): PROOF server being used to validate WDL unit tests (class defined in cromwell.py)
-        wdl_path (PosixPath): location of the WDL script to validate via PROOF
+        cromwell_api (CromwellApi): Cromwell server being used to validate WDL unit tests (class defined in cromwell.py)
+        wdl_path (PosixPath): location of the WDL script to validate via WOMtool
     """
     if not wdl_path.name.startswith("badVal"):
         res = cromwell_api.validate(wdl_path=wdl_path)
@@ -38,8 +38,8 @@ def test_validate_bad_wdl(cromwell_api, wdl_path):
     Cromwell validate route (/api/womtool/v1/describe)
 
     Args:
-        cromwell_api (CromwellApi): PROOF server being used to validate WDL unit tests (class defined in cromwell.py)
-        wdl_path (PosixPath): location of the WDL script to validate via PROOF
+        cromwell_api (CromwellApi): Cromwell server being used to validate WDL unit tests (class defined in cromwell.py)
+        wdl_path (PosixPath): location of the WDL script to validate via WOMtool
     """
     message_check = {
         "badValMissingValue.wdl": "Cannot lookup value 'docker_image'"

--- a/tests/cromwellapi/test-version.py
+++ b/tests/cromwellapi/test-version.py
@@ -3,5 +3,11 @@ import pytest
 
 @pytest.mark.vcr
 def test_version(cromwell_api):
+    """
+    Test the Cromwell version endpoint (/engine/v1/version)
+
+    We're not testing exact version number as we just care about the data type
+    """
+
     res = cromwell_api.version()
     assert isinstance(res, dict)

--- a/tests/cromwellapi/test-version.py
+++ b/tests/cromwellapi/test-version.py
@@ -7,6 +7,9 @@ def test_version(cromwell_api):
     Test the Cromwell version endpoint (/engine/v1/version)
 
     We're not testing exact version number as we just care about the data type
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
     """
 
     res = cromwell_api.version()


### PR DESCRIPTION
fix #114 

- New `docs` folder with `README` and a single docs file 
- The single file is `architecture.md`
- With a Note alert in main readme, link to docs folder 
- To all test-.py files note which Cromwell API route they are testing

Questions:
1. Should we move any other docs into the `docs/` folder from the main README?
2. Should we add any new docs to the `docs/` folder that we don't currently have? 