### PR TITLE
Fix rewrite cassettes action

### DIFF
--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
         with:
-          version: "0.6.3"
+          version: "0.6.14"
 
       - name: Set up Python
         run: uv python install 3.13

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -49,7 +49,7 @@ jobs:
           delete-branch: true
           add-paths: |
             tests/cromwellapi/cassettes/*
-            tests/cromwellapi/mocked_submissions.json
+            tests/cromwellapi/mocked_submissions/*
           assignees: sckott
           reviewers: |
             sckott


### PR DESCRIPTION
via failed rewrite scheduled run https://github.com/FredHutch/wdl-unit-tests/actions/runs/14555537432/job/40832024369 

Can I get a quick review? 

Forgot to change the pattern we look for in this PR step to look for files within `tests/cromwellapi/mocked_submissions/*` rather than `tests/cromwellapi/mocked_submissions.json` 

and bumped `uv` while we're here