### PR TITLE
Rewrite cassettes retry

### DIFF
--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -37,7 +37,11 @@ jobs:
           PATH_ROOTS: "op://PROOF/PROOF_PATH_ROOTS/credential"
 
       - name: Run tests
-        run: make test_api_rewrite
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 3
+          timeout_minutes: 5
+          command: make test_api_rewrite
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -48,15 +48,14 @@ jobs:
           fi
 
           # Extract test file paths
-          echo "========== Tests passed =========="
           passed_cassettes=$(jq -r '.tests[] | select(.outcome=="passed") | .cassette' results.json | grep -v "null" || echo "")
           passed_mock_jsons=$(jq -r '.tests[] | select(.outcome=="passed") | .mock_json' results.json | grep -v "null" || echo "")
 
-          echo "========== Tests failed =========="
           failed_cassettes=$(jq -r '.tests[] | select(.outcome=="failed") | .cassette' results.json | grep -v "null" || echo "")
           failed_mock_jsons=$(jq -r '.tests[] | select(.outcome=="failed") | .mock_json' results.json | grep -v "null" || echo "")
 
           # Display passed tests
+          echo "========== Tests passed =========="
           if [ -n "$passed_cassettes" ]; then
             echo "$passed_cassettes"
           else
@@ -64,6 +63,7 @@ jobs:
           fi
 
           # Display failed tests
+          echo "========== Tests failed =========="
           if [ -n "$failed_cassettes" ]; then
             echo "$failed_cassettes"
           else
@@ -90,7 +90,6 @@ jobs:
           fi
 
       - name: Create a pull request
-        if: steps.process-changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
-          version: "0.6.14"
+          version: "0.7.3"
 
       - name: Set up Python
         run: uv python install 3.13
@@ -36,28 +36,61 @@ jobs:
           PROOF_API_TOKEN_DEV: "op://PROOF/PROOF_Test_User/dev token"
           PATH_ROOTS: "op://PROOF/PROOF_PATH_ROOTS/credential"
 
-      - name: Run tests and process files
-        continue-on-error: true
+      - name: Run tests and process changes
+        id: process-changes
         run: |
-          make test_api_rewrite_json_report
+          make test_api_rewrite_json_report || true
 
-          # Extract files to add to PR (passed cassettes and mock JSONs)
-          mkdir -p .github/changes
-          jq -r '.tests[] | select(.outcome=="passed") | .cassette' results.json > .github/changes/cassettes_passed.txt
-          jq -r '.tests[] | select(.outcome=="passed") | .mock_json' results.json > .github/changes/mock_jsons.txt
-          jq -r '.tests[] | select(.outcome=="failed") | .cassette' results.json > .github/changes/cassettes_failed.txt
+          # Check if results.json exists and has valid content
+          if [ ! -f results.json ]; then
+            echo "Error: results.json not found. Tests may have failed completely."
+            exit 1
+          fi
 
-          # Show test results
-          echo "Tests passed:"
-          cat .github/changes/cassettes_passed.txt || echo "None"
+          # Extract test file paths
+          echo "========== Tests passed =========="
+          passed_cassettes=$(jq -r '.tests[] | select(.outcome=="passed") | .cassette' results.json | grep -v "null" || echo "")
+          passed_mock_jsons=$(jq -r '.tests[] | select(.outcome=="passed") | .mock_json' results.json | grep -v "null" || echo "")
 
-          echo "Tests failed:"
-          cat .github/changes/cassettes_failed.txt || echo "None"
+          echo "========== Tests failed =========="
+          failed_cassettes=$(jq -r '.tests[] | select(.outcome=="failed") | .cassette' results.json | grep -v "null" || echo "")
+          failed_mock_jsons=$(jq -r '.tests[] | select(.outcome=="failed") | .mock_json' results.json | grep -v "null" || echo "")
 
-          # Combine passed tests files for PR
-          cat .github/changes/cassettes_passed.txt .github/changes/mock_jsons.txt | sort | uniq > .github/changes/files_to_commit.txt
+          # Display passed tests
+          if [ -n "$passed_cassettes" ]; then
+            echo "$passed_cassettes"
+          else
+            echo "No passed cassettes found"
+          fi
+
+          # Display failed tests
+          if [ -n "$failed_cassettes" ]; then
+            echo "$failed_cassettes"
+          else
+            echo "No failed cassettes found"
+          fi
+
+          # Handle failed tests by not committing their changes
+          if [ -n "$failed_cassettes" ]; then
+            echo "Reverting changes to failed test cassettes..."
+            echo "$failed_cassettes" | while read -r file; do
+              if [ -n "$file" ]; then
+                git checkout -- "$file" || true
+              fi
+            done
+          fi
+
+          if [ -n "$failed_mock_jsons" ]; then
+            echo "Reverting changes to failed test mock JSONs..."
+            echo "$failed_mock_jsons" | while read -r file; do
+              if [ -n "$file" ]; then
+                git checkout -- "$file" || true
+              fi
+            done
+          fi
 
       - name: Create a pull request
+        if: steps.process-changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +98,9 @@ jobs:
           title: "Update vcr cassettes"
           commit-message: "updated vcr cassettes"
           delete-branch: true
-          add-paths: .github/changes/files_to_commit.txt
+          add-paths: |
+            tests/cromwellapi/cassettes/*
+            tests/cromwellapi/mocked_submissions/*
           assignees: sckott
           reviewers: |
             sckott

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -39,22 +39,24 @@ jobs:
       - name: Run tests and process files
         run: |
           make test_api_rewrite_json_report
-          
+
           # Extract files to add to PR (passed cassettes and mock JSONs)
           mkdir -p .github/changes
           jq -r '.tests[] | select(.outcome=="passed") | .cassette' results.json > .github/changes/cassettes_passed.txt
           jq -r '.tests[] | select(.outcome=="passed") | .mock_json' results.json > .github/changes/mock_jsons.txt
           jq -r '.tests[] | select(.outcome=="failed") | .cassette' results.json > .github/changes/cassettes_failed.txt
-          
+
           # Show test results
           echo "Tests passed:"
           cat .github/changes/cassettes_passed.txt || echo "None"
-          
+
           echo "Tests failed:"
           cat .github/changes/cassettes_failed.txt || echo "None"
-          
+
           # Combine passed tests files for PR
           cat .github/changes/cassettes_passed.txt .github/changes/mock_jsons.txt | sort | uniq > .github/changes/files_to_commit.txt
+
+          exit 0
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -40,7 +40,7 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           max_attempts: 3
-          timeout_minutes: 5
+          timeout_minutes: 30
           command: make test_api_rewrite
 
       - name: Create a pull request

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run tests
         id: run-tests
         run: |
-          make test_api_cached_json_report
+          make test_api_rewrite_json_report
           cassettes_passed=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c)
           echo "cassettes_passed=$cassettes_passed" >> $GITHUB_OUTPUT
 
@@ -53,11 +53,11 @@ jobs:
 
       - name: List all cassettes passed
         run: |
-          echo "Tests passed: ${{ steps.run-tests.outputs.cassettes_passed }}"
+          echo "Tests passed: ${{ fromJson(steps.run-tests.outputs.cassettes_passed) }}"
 
       - name: List all cassettes failed
         run: |
-          echo "Tests failed: ${{ steps.run-tests.outputs.cassettes_failed }}"
+          echo "Tests failed: ${{ fromJson(steps.run-tests.outputs.cassettes_failed) }}"
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v7
@@ -68,8 +68,8 @@ jobs:
           commit-message: "updated vcr cassettes"
           delete-branch: true
           add-paths: |
-            ${{ fromJson(steps.run-tests.outputs.cassettes_passed) }}
-            ${{ fromJson(steps.run-tests.outputs.mock_jsons) }}
+            ${{ steps.run-tests.outputs.cassettes_passed }}
+            ${{ steps.run-tests.outputs.mock_jsons }}
           assignees: sckott
           reviewers: |
             sckott

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -51,6 +51,13 @@ jobs:
 
           exit 0
 
+      - name: Prep paths to add
+        run: |
+          mock_jsons_paths=$(fromJson(steps.run-tests.outputs.mock_jsons) | jq '.[]' | jq -r)
+          cassettes_passed_paths=$(fromJson(steps.run-tests.outputs.cassettes_passed) | jq '.[]' | jq -r)
+          echo "mock_jsons_paths=$mock_jsons_paths" >> $GITHUB_OUTPUT
+          echo "cassettes_passed_paths=$cassettes_passed_paths" >> $GITHUB_OUTPUT
+
       - name: List all cassettes passed
         run: |
           echo "Tests passed: ${{ fromJson(steps.run-tests.outputs.cassettes_passed) }}"
@@ -68,8 +75,8 @@ jobs:
           commit-message: "updated vcr cassettes"
           delete-branch: true
           add-paths: |
-            ${{ fromJson(steps.run-tests.outputs.cassettes_passed) | jq '.[]' | jq -r }}
-            ${{ fromJson(steps.run-tests.outputs.mock_jsons) | jq '.[]' | jq -r }}
+            ${{ steps.run-tests.outputs.cassettes_passed_paths }}
+            ${{ steps.run-tests.outputs.mock_jsons_paths }}
           assignees: sckott
           reviewers: |
             sckott

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -37,6 +37,7 @@ jobs:
           PATH_ROOTS: "op://PROOF/PROOF_PATH_ROOTS/credential"
 
       - name: Run tests and process files
+        continue-on-error: true
         run: |
           make test_api_rewrite_json_report
 
@@ -55,8 +56,6 @@ jobs:
 
           # Combine passed tests files for PR
           cat .github/changes/cassettes_passed.txt .github/changes/mock_jsons.txt | sort | uniq > .github/changes/files_to_commit.txt
-
-          exit 0
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -55,7 +55,7 @@ jobs:
         id: prep-paths-to-add
         run: |
           mock_jsons_paths=$( ${{ steps.run-tests.outputs.mock_jsons }} | jq '.[]' | jq -r)
-          cassettes_passed_paths=$( ${{ steps.run-tests.outputs.cassettes_passed }} | jq '.[]' | jq -r)
+          cassettes_passed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r)
           echo "mock_jsons_paths=$mock_jsons_paths" >> $GITHUB_OUTPUT
           echo "cassettes_passed_paths=$cassettes_passed_paths" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -42,8 +42,13 @@ jobs:
           make test_api_cached_json_report
           cassettes_passed=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c)
           echo "cassettes_passed=$cassettes_passed" >> $GITHUB_OUTPUT
+
+          mock_jsons=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .mock_json'  | jq -s | jq -c)
+          echo "mock_jsons=$mock_jsons" >> $GITHUB_OUTPUT
+
           cassettes_failed=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette' | jq -s | jq -c)
           echo "cassettes_failed=$cassettes_failed" >> $GITHUB_OUTPUT
+
           exit 0
 
       - name: List all cassettes passed
@@ -52,7 +57,7 @@ jobs:
 
       - name: List all cassettes failed
         run: |
-          echo "Tests failed: ${{ steps.run-tests.outputs.cassettes_passed }}"
+          echo "Tests failed: ${{ steps.run-tests.outputs.cassettes_failed }}"
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v7
@@ -63,8 +68,8 @@ jobs:
           commit-message: "updated vcr cassettes"
           delete-branch: true
           add-paths: |
-            tests/cromwellapi/cassettes/*
-            tests/cromwellapi/mocked_submissions/*
+            ${{ fromJson(steps.run-tests.outputs.cassettes_passed) }}
+            ${{ fromJson(steps.run-tests.outputs.mock_jsons) }}
           assignees: sckott
           reviewers: |
             sckott

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -36,33 +36,25 @@ jobs:
           PROOF_API_TOKEN_DEV: "op://PROOF/PROOF_Test_User/dev token"
           PATH_ROOTS: "op://PROOF/PROOF_PATH_ROOTS/credential"
 
-      - name: Run tests
-        id: run-tests
+      - name: Run tests and process files
         run: |
           make test_api_rewrite_json_report
-
-          cassettes_passed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r | base64)
-          echo "cassettes_passed_paths=$cassettes_passed_paths" >> $GITHUB_OUTPUT
-
-          mock_jsons_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .mock_json'  | jq -s | jq -c | jq '.[]' | jq -r | base64)
-          echo "mock_jsons_paths=$mock_jsons_paths" >> $GITHUB_OUTPUT
-
-          cassettes_failed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r | base64)
-          echo "cassettes_failed_paths=$cassettes_failed_paths" >> $GITHUB_OUTPUT
-
-          exit 0
-
-      - name: List all cassettes passed
-        run: |
-          PATHS="${{ steps.run-tests.outputs.cassettes_passed_paths }}"
-          PASSED=$(echo "$PATHS" | base64 --decode)
-          echo "Tests passed: $PASSED"
-
-      - name: List all cassettes failed
-        run: |
-          PATHS="${{ steps.run-tests.outputs.cassettes_failed_paths }}"
-          FAILED=$(echo "$PATHS" | base64 --decode)
-          echo "Tests failed: $FAILED"
+          
+          # Extract files to add to PR (passed cassettes and mock JSONs)
+          mkdir -p .github/changes
+          jq -r '.tests[] | select(.outcome=="passed") | .cassette' results.json > .github/changes/cassettes_passed.txt
+          jq -r '.tests[] | select(.outcome=="passed") | .mock_json' results.json > .github/changes/mock_jsons.txt
+          jq -r '.tests[] | select(.outcome=="failed") | .cassette' results.json > .github/changes/cassettes_failed.txt
+          
+          # Show test results
+          echo "Tests passed:"
+          cat .github/changes/cassettes_passed.txt || echo "None"
+          
+          echo "Tests failed:"
+          cat .github/changes/cassettes_failed.txt || echo "None"
+          
+          # Combine passed tests files for PR
+          cat .github/changes/cassettes_passed.txt .github/changes/mock_jsons.txt | sort | uniq > .github/changes/files_to_commit.txt
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v7
@@ -72,9 +64,7 @@ jobs:
           title: "Update vcr cassettes"
           commit-message: "updated vcr cassettes"
           delete-branch: true
-          add-paths: |
-            $( ${{ steps.run-tests.outputs.cassettes_passed_paths }} | base64 --decode )
-            $( ${{ steps.run-tests.outputs.mock_jsons_paths }} | base64 --decode )
+          add-paths: .github/changes/files_to_commit.txt
           assignees: sckott
           reviewers: |
             sckott

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -46,12 +46,13 @@ jobs:
           mock_jsons=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .mock_json'  | jq -s | jq -c)
           echo "mock_jsons=$mock_jsons" >> $GITHUB_OUTPUT
 
-          cassettes_failed=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette' | jq -s | jq -c)
-          echo "cassettes_failed=$cassettes_failed" >> $GITHUB_OUTPUT
+          cassettes_failed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r)
+          echo "cassettes_failed_paths=$cassettes_failed_paths" >> $GITHUB_OUTPUT
 
           exit 0
 
       - name: Prep paths to add
+        id: prep-paths-to-add
         run: |
           mock_jsons_paths=$( ${{ steps.run-tests.outputs.mock_jsons }} | jq '.[]' | jq -r)
           cassettes_passed_paths=$( ${{ steps.run-tests.outputs.cassettes_passed }} | jq '.[]' | jq -r)
@@ -60,11 +61,11 @@ jobs:
 
       - name: List all cassettes passed
         run: |
-          echo "Tests passed: ${{ fromJson(steps.run-tests.outputs.cassettes_passed) }}"
+          echo "Tests passed: ${{ steps.prep-paths-to-add.outputs.cassettes_passed_paths }}"
 
       - name: List all cassettes failed
         run: |
-          echo "Tests failed: ${{ fromJson(steps.run-tests.outputs.cassettes_failed) }}"
+          echo "Tests failed: ${{ steps.run-tests.outputs.cassettes_failed_paths }}"
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -68,8 +68,8 @@ jobs:
           commit-message: "updated vcr cassettes"
           delete-branch: true
           add-paths: |
-            ${{ steps.run-tests.outputs.cassettes_passed }}
-            ${{ steps.run-tests.outputs.mock_jsons }}
+            ${{ fromJson(steps.run-tests.outputs.cassettes_passed) }}
+            ${{ fromJson(steps.run-tests.outputs.mock_jsons) }}
           assignees: sckott
           reviewers: |
             sckott

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -53,8 +53,8 @@ jobs:
 
       - name: Prep paths to add
         run: |
-          mock_jsons_paths=$(fromJson(steps.run-tests.outputs.mock_jsons) | jq '.[]' | jq -r)
-          cassettes_passed_paths=$(fromJson(steps.run-tests.outputs.cassettes_passed) | jq '.[]' | jq -r)
+          mock_jsons_paths=$( ${{ steps.run-tests.outputs.mock_jsons }} | jq '.[]' | jq -r)
+          cassettes_passed_paths=$( ${{ steps.run-tests.outputs.cassettes_passed }} | jq '.[]' | jq -r)
           echo "mock_jsons_paths=$mock_jsons_paths" >> $GITHUB_OUTPUT
           echo "cassettes_passed_paths=$cassettes_passed_paths" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -40,28 +40,21 @@ jobs:
         id: run-tests
         run: |
           make test_api_rewrite_json_report
-          cassettes_passed=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c)
-          echo "cassettes_passed=$cassettes_passed" >> $GITHUB_OUTPUT
 
-          mock_jsons=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .mock_json'  | jq -s | jq -c)
-          echo "mock_jsons=$mock_jsons" >> $GITHUB_OUTPUT
+          cassettes_passed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r)
+          echo "cassettes_passed_paths=$cassettes_passed_paths" >> $GITHUB_OUTPUT
+
+          mock_jsons_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .mock_json'  | jq -s | jq -c | jq '.[]' | jq -r)
+          echo "mock_jsons_paths=$mock_jsons_paths" >> $GITHUB_OUTPUT
 
           cassettes_failed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r)
           echo "cassettes_failed_paths=$cassettes_failed_paths" >> $GITHUB_OUTPUT
 
           exit 0
 
-      - name: Prep paths to add
-        id: prep-paths-to-add
-        run: |
-          mock_jsons_paths=$( ${{ steps.run-tests.outputs.mock_jsons }} | jq '.[]' | jq -r)
-          cassettes_passed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r)
-          echo "mock_jsons_paths=$mock_jsons_paths" >> $GITHUB_OUTPUT
-          echo "cassettes_passed_paths=$cassettes_passed_paths" >> $GITHUB_OUTPUT
-
       - name: List all cassettes passed
         run: |
-          echo "Tests passed: ${{ steps.prep-paths-to-add.outputs.cassettes_passed_paths }}"
+          echo "Tests passed: ${{ steps.run-tests.outputs.cassettes_passed_paths }}"
 
       - name: List all cassettes failed
         run: |

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -41,24 +41,28 @@ jobs:
         run: |
           make test_api_rewrite_json_report
 
-          cassettes_passed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r)
+          cassettes_passed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r | base64)
           echo "cassettes_passed_paths=$cassettes_passed_paths" >> $GITHUB_OUTPUT
 
-          mock_jsons_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .mock_json'  | jq -s | jq -c | jq '.[]' | jq -r)
+          mock_jsons_paths=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .mock_json'  | jq -s | jq -c | jq '.[]' | jq -r | base64)
           echo "mock_jsons_paths=$mock_jsons_paths" >> $GITHUB_OUTPUT
 
-          cassettes_failed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r)
+          cassettes_failed_paths=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette' | jq -s | jq -c | jq '.[]' | jq -r | base64)
           echo "cassettes_failed_paths=$cassettes_failed_paths" >> $GITHUB_OUTPUT
 
           exit 0
 
       - name: List all cassettes passed
         run: |
-          echo "Tests passed: ${{ steps.run-tests.outputs.cassettes_passed_paths }}"
+          PATHS="${{ steps.run-tests.outputs.cassettes_passed_paths }}"
+          PASSED=$(echo "$PATHS" | base64 --decode)
+          echo "Tests passed: $PASSED"
 
       - name: List all cassettes failed
         run: |
-          echo "Tests failed: ${{ steps.run-tests.outputs.cassettes_failed_paths }}"
+          PATHS="${{ steps.run-tests.outputs.cassettes_failed_paths }}"
+          FAILED=$(echo "$PATHS" | base64 --decode)
+          echo "Tests failed: $FAILED"
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v7
@@ -69,8 +73,8 @@ jobs:
           commit-message: "updated vcr cassettes"
           delete-branch: true
           add-paths: |
-            ${{ steps.run-tests.outputs.cassettes_passed_paths }}
-            ${{ steps.run-tests.outputs.mock_jsons_paths }}
+            $( ${{ steps.run-tests.outputs.cassettes_passed_paths }} | base64 --decode )
+            $( ${{ steps.run-tests.outputs.mock_jsons_paths }} | base64 --decode )
           assignees: sckott
           reviewers: |
             sckott

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -68,8 +68,8 @@ jobs:
           commit-message: "updated vcr cassettes"
           delete-branch: true
           add-paths: |
-            ${{ fromJson(steps.run-tests.outputs.cassettes_passed) }}
-            ${{ fromJson(steps.run-tests.outputs.mock_jsons) }}
+            ${{ fromJson(steps.run-tests.outputs.cassettes_passed) | jq '.[]' | jq -r }}
+            ${{ fromJson(steps.run-tests.outputs.mock_jsons) | jq '.[]' | jq -r }}
           assignees: sckott
           reviewers: |
             sckott

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -37,11 +37,22 @@ jobs:
           PATH_ROOTS: "op://PROOF/PROOF_PATH_ROOTS/credential"
 
       - name: Run tests
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 3
-          timeout_minutes: 30
-          command: make test_api_rewrite
+        id: run-tests
+        run: |
+          make test_api_rewrite_json_report
+          cassettes_passed=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette ')
+          echo "cassettes_passed=$cassettes_passed" >> $GITHUB_OUTPUT
+          cassettes_failed=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette ')
+          echo "cassettes_failed=$cassettes_failed" >> $GITHUB_OUTPUT
+          exit 0
+
+      - name: List all cassettes passed
+        run: |
+          echo "Tests passed: ${{ steps.run-tests.outputs.cassettes_passed }}"
+
+      - name: List all cassettes failed
+        run: |
+          echo "Tests failed: ${{ steps.run-tests.outputs.cassettes_passed }}"
 
       - name: Create a pull request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Run tests
         id: run-tests
         run: |
-          make test_api_rewrite_json_report
-          cassettes_passed=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette ')
+          make test_api_cached_json_report
+          cassettes_passed=$(cat results.json | jq '.tests[] | select(.outcome=="passed") | .cassette' | jq -s | jq -c)
           echo "cassettes_passed=$cassettes_passed" >> $GITHUB_OUTPUT
-          cassettes_failed=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette ')
+          cassettes_failed=$(cat results.json | jq '.tests[] | select(.outcome=="failed") | .cassette' | jq -s | jq -c)
           echo "cassettes_failed=$cassettes_failed" >> $GITHUB_OUTPUT
           exit 0
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ uv.lock
 
 # Ruff
 .ruff_cache
+
+# testing locally
+results*.json

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ test_api_rewrite_json_report: check_env_vars
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \
 	--color=yes --record-mode=rewrite --verbose -s \
-	tests/cromwellapi/
+	tests/cromwellapi/test-failures.py \
+	tests/cromwellapi/test-outputs.py
 
 ipython: check_env_vars
 	cd tests/cromwellapi/ && \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test_api_rewrite_json_report: check_env_vars
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \
 	--color=yes --record-mode=rewrite --verbose -s \
-	tests/cromwellapi/test-failures.py
+	tests/cromwellapi/
 
 ipython: check_env_vars
 	cd tests/cromwellapi/ && \

--- a/Makefile
+++ b/Makefile
@@ -43,18 +43,11 @@ test_api_rewrite: check_env_vars
 	--color=yes --record-mode=rewrite --verbose -s \
 	tests/cromwellapi/
 
-test_api_cached_json_report: check_env_vars
-	op run -- uv run pytest -n $(WORKERS) \
-	--json-report --json-report-file=results.json \
-	--color=yes --record-mode=once --verbose -s \
-	tests/cromwellapi/
-
 test_api_rewrite_json_report: check_env_vars
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \
 	--color=yes --record-mode=rewrite --verbose -s \
-	tests/cromwellapi/test-failures.py \
-	tests/cromwellapi/test-outputs.py
+	tests/cromwellapi/
 
 ipython: check_env_vars
 	cd tests/cromwellapi/ && \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test_api_rewrite_json_report: check_env_vars
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \
 	--color=yes --record-mode=rewrite --verbose -s \
-	tests/cromwellapi/
+	tests/cromwellapi/test-metadata.py
 
 ipython: check_env_vars
 	cd tests/cromwellapi/ && \

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,12 @@ test_api_rewrite: check_env_vars
 	--color=yes --record-mode=rewrite --verbose -s \
 	tests/cromwellapi/
 
+test_api_cached_json_report: check_env_vars
+	op run -- uv run pytest -n $(WORKERS) \
+	--json-report --json-report-file=results.json \
+	--color=yes --record-mode=once --verbose -s \
+	tests/cromwellapi/
+
 test_api_rewrite_json_report: check_env_vars
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test_api_rewrite_json_report: check_env_vars
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \
 	--color=yes --record-mode=rewrite --verbose -s \
-	tests/cromwellapi/
+	tests/cromwellapi/test-failures.py
 
 ipython: check_env_vars
 	cd tests/cromwellapi/ && \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test_api_rewrite_json_report: check_env_vars
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \
 	--color=yes --record-mode=rewrite --verbose -s \
-	tests/cromwellapi/test-metadata.py
+	tests/cromwellapi/test-failures.py
 
 ipython: check_env_vars
 	cd tests/cromwellapi/ && \

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,20 @@ check_env_vars:
 	$(call check_defined, PROOF_API_TOKEN_DEV, env var for test PROOF user)
 
 test_api_cached: check_env_vars
-	op run -- uv run pytest -n $(WORKERS) --color=yes --record-mode=once --verbose -s tests/cromwellapi/
+	op run -- uv run pytest -n $(WORKERS) \
+	--color=yes --record-mode=once --verbose -s \
+	tests/cromwellapi/
 
 test_api_rewrite: check_env_vars
-	op run -- uv run pytest -n $(WORKERS) --color=yes --record-mode=rewrite --verbose -s tests/cromwellapi/
+	op run -- uv run pytest -n $(WORKERS) \
+	--color=yes --record-mode=rewrite --verbose -s \
+	tests/cromwellapi/
+
+test_api_rewrite_json_report: check_env_vars
+	op run -- uv run pytest -n $(WORKERS) \
+	--json-report --json-report-file=results.json \
+	--color=yes --record-mode=rewrite --verbose -s \
+	tests/cromwellapi/
 
 ipython: check_env_vars
 	cd tests/cromwellapi/ && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "tenacity>=9.0.0",
   "vcrpy>=7.0.0",
   "pytest-xdist>=3.6.1",
+  "pytest-json-report>=1.5.0",
 ]
 
 [dependency-groups]

--- a/tests/cromwellapi/conftest.py
+++ b/tests/cromwellapi/conftest.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import pytest
 from constants import SLEEP_FINAL_STATE
@@ -101,10 +102,10 @@ def test_name(request):
     return request.node.name
 
 
-def modify_path(path):
+def add_cassette_path(path):
     """
     Examples:
-      modify_path("tests/cromwellapi/test-call.py::test_call_final[globNonmatching.wdl]")
+      add_cassette_path("tests/cromwellapi/test-call.py::test_call_final[globNonmatching.wdl]")
       #> 'tests/cromwellapi/cassettes/test-call/test_call_final[globNonmatching.wdl].yaml'
     """
     path = path.replace(".py::", "/")
@@ -113,6 +114,21 @@ def modify_path(path):
     return path
 
 
+def add_mock_json_path(path):
+    """
+    Examples:
+      add_mock_json_path("tests/cromwellapi/test-call.py::test_call_final[globNonmatching.wdl]")
+      #> 'tests/cromwellapi/mocked_submissions/test_call_final[globNonmatching.wdl].json'
+    """
+    path = re.sub("test-.+.py::", "", path)
+    path = path.replace(
+        "tests/cromwellapi", "tests/cromwellapi/mocked_submissions"
+    )
+    path = path + ".json"
+    return path
+
+
 def pytest_json_modifyreport(json_report):
     for test_data in json_report["tests"]:
-        test_data["cassette"] = modify_path(test_data["nodeid"])
+        test_data["cassette"] = add_cassette_path(test_data["nodeid"])
+        test_data["mock_json"] = add_mock_json_path(test_data["nodeid"])

--- a/tests/cromwellapi/conftest.py
+++ b/tests/cromwellapi/conftest.py
@@ -99,3 +99,20 @@ def vcr_config():
 @pytest.fixture
 def test_name(request):
     return request.node.name
+
+
+def modify_path(path):
+    """
+    Examples:
+      modify_path("tests/cromwellapi/test-call.py::test_call_final[globNonmatching.wdl]")
+      #> 'tests/cromwellapi/cassettes/test-call/test_call_final[globNonmatching.wdl].yaml'
+    """
+    path = path.replace(".py::", "/")
+    path = path.replace("tests/cromwellapi", "tests/cromwellapi/cassettes")
+    path = path + ".yaml"
+    return path
+
+
+def pytest_json_modifyreport(json_report):
+    for test_data in json_report["tests"]:
+        test_data["cassette"] = modify_path(test_data["nodeid"])

--- a/tests/cromwellapi/conftest.py
+++ b/tests/cromwellapi/conftest.py
@@ -128,6 +128,7 @@ def add_mock_json_path(path):
     return path
 
 
+@pytest.hookimpl(optionalhook=True)
 def pytest_json_modifyreport(json_report):
     for test_data in json_report["tests"]:
         test_data["cassette"] = add_cassette_path(test_data["nodeid"])


### PR DESCRIPTION
fix #168 

definitely squash and merge - lots of iterating to fix actions commits

Here's a run of this new workflow: https://github.com/FredHutch/wdl-unit-tests/actions/runs/14801625090/job/41732524382

Here's the generated PR from the above workflow run: https://github.com/FredHutch/wdl-unit-tests/pull/169

Changes here:
- now using `pytest` plugin `pytest-json-report`
- added fixture `pytest_json_modifyreport` that when the `--json-report` flag is used with `pytest` a report of test results is written to a json file. this fixture is not used when the `--json-report` flag is absent via this line `@pytest.hookimpl(optionalhook=True)`
- reformatted some make commands 
- new make command `test_api_rewrite_json_report` to do cassette rewrites AND generate a json report
- modified the rewrite cassettes github action yaml to
  - generate the json report when testing
  - always succeed via `exit 0` (otherwise any failures would not let us proceed)
  - open a PR with only the paths to cassettes and mock json files for tests that passed (failed test files are ignored)
  - then either Sean or I would merge the PR
  - the idea is for likely me to investigate any failures and fix those, then we can run rewrite cassettes again and merge that

¿Bueno?