### PR TITLE
add make cmds for running java cromwell run and validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,14 @@ test_api_rewrite_json_report: check_env_vars
 	--color=yes --record-mode=rewrite --verbose -s \
 	tests/cromwellapi/
 
+test_java_validate:
+	@echo "Validating WDL files with womtool validate..."
+	@bash scripts/cromwell_validate.sh
+
+test_java_run:
+	@echo "Running WDL files with cromwell run..."
+	@bash scripts/cromwell_run.sh
+
 ipython: check_env_vars
 	cd tests/cromwellapi/ && \
 	op run --no-masking -- uv run --with rich --with ipython python -m IPython

--- a/scripts/cromwell_run.sh
+++ b/scripts/cromwell_run.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Source the utility script with the find_tool function
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/find_tool.sh"
+
+# Find the cromwell JAR
+CROMWELL_PATH=$(find_cromwell)
+
+# Check if cromwell was found
+if [ -z "$CROMWELL_PATH" ]; then
+    echo "Error: cromwell-87.jar not found on your system."
+    echo "Please download it or specify the path manually by setting the CROMWELL_PATH environment variable."
+    exit 1
+fi
+
+echo "Found cromwell at: $CROMWELL_PATH"
+export CROMWELL_PATH
+
+# Run tests on all WDL files
+for i in $(find . -type f -name "*.wdl" -exec dirname {} \; | sort -u | sed 's|^\./||'); do
+  echo "$i"
+  uv run pytest tests/cromwelljava/test-run.py --wdl-path=$i --verbose -s
+  echo -e "\n\n"
+done

--- a/scripts/cromwell_validate.sh
+++ b/scripts/cromwell_validate.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Source the utility script with the find_tool function
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/find_tool.sh"
+
+# Find the womtool JAR
+WOMTOOL_PATH=$(find_tool)
+
+# Check if womtool was found
+if [ -z "$WOMTOOL_PATH" ]; then
+    echo "Error: womtool-87.jar not found on your system."
+    echo "Please download it or specify the path manually by setting the WOMTOOL_PATH environment variable."
+    exit 1
+fi
+
+echo "Found womtool at: $WOMTOOL_PATH"
+export WOMTOOL_PATH
+
+# Run tests on all WDL files
+for i in $(find . -type f -name "*.wdl" -exec dirname {} \; | sort -u | sed 's|^\./||'); do
+  echo "$i"
+  uv run pytest tests/cromwelljava/test-validate.py --wdl-path=$i --verbose -s
+  echo -e "\n\n"
+done

--- a/scripts/cromwell_validate.sh
+++ b/scripts/cromwell_validate.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/find_tool.sh"
 
 # Find the womtool JAR
-WOMTOOL_PATH=$(find_tool)
+WOMTOOL_PATH=$(find_womtool)
 
 # Check if womtool was found
 if [ -z "$WOMTOOL_PATH" ]; then

--- a/scripts/find_tool.sh
+++ b/scripts/find_tool.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Find a Cromwell-related JAR file
+find_jar() {
+    local jar_name="$1"
+    local env_var_name="$2"
+
+    # Check if environment variable is already set
+    if [ ! -z "${!env_var_name}" ]; then
+        # Verify the path exists
+        if [ -f "${!env_var_name}" ]; then
+            echo "${!env_var_name}"
+            return 0
+        else
+            echo "Warning: $env_var_name is set but file does not exist: ${!env_var_name}" >&2
+        fi
+    fi
+
+    # Check common locations for the JAR file
+    possible_locations=(
+        # Home directory and subdirectories
+        "$HOME/*/$jar_name"
+        "$HOME/*/*/$jar_name"
+        "$HOME/*/*/*/$jar_name"
+        "$HOME/*/*/*/*/$jar_name"
+        # Current directory and subdirectories
+        "./*/$jar_name"
+        "./*/*/$jar_name"
+        "./*/*/*/$jar_name"
+        # Common specific paths
+        "$HOME/github/cromwell/$jar_name"
+        "$HOME/cromwell/$jar_name"
+        "$HOME/Downloads/$jar_name"
+    )
+
+    # Look through each location
+    for pattern in "${possible_locations[@]}"; do
+        found_paths=$(find ${pattern} 2>/dev/null)
+        if [ ! -z "$found_paths" ]; then
+            # Take the first match
+            echo "$found_paths" | head -n 1
+            return 0
+        fi
+    done
+
+    # If not found in common locations, do a broader search
+    echo "$jar_name not found in common locations. Performing a broader search (this may take a while)..." >&2
+
+    # Search in home directory (limit depth to avoid excessive searching)
+    found_path=$(find "$HOME" -name "$jar_name" -type f -depth -10 2>/dev/null | head -n 1)
+
+    if [ ! -z "$found_path" ]; then
+        echo "$found_path"
+        return 0
+    fi
+
+    # Not found
+    echo ""
+    return 1
+}
+
+# Wrapper function for womtool-87.jar
+find_womtool() {
+    find_jar "womtool-87.jar" "WOMTOOL_PATH"
+}
+
+# Wrapper function for cromwell-87.jar
+find_cromwell() {
+    find_jar "cromwell-87.jar" "CROMWELL_PATH"
+}
+
+# If this script is being executed directly, run the functions
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "Finding womtool:"
+    find_womtool
+    echo "Finding cromwell:"
+    find_cromwell
+fi


### PR DESCRIPTION
- add scripts dir with scripts for running cromwell tools
- find_tools.sh finds the womtool.jar and cromwell.jar files
- cromwell_run.sh runs cromwell run
- cromwell_validate runs womtool validate



I thought it would be nice to have equivalent make commands to run java based tests in addition to the API tests. this approach uses a bash function in find_tools.sh to find the .jar files and then each WDL dir is run through a bash for loop. 

Can you please try and give feedback?
