### PR TITLE
Regulated data testing

### DIFF
--- a/.env-regulated
+++ b/.env-regulated
@@ -1,0 +1,2 @@
+PROOF_REGULATED_DATA=op://PROOF/PROOF_Test_User/regulated_data
+PROOF_SLURM_ACCOUNT=op://PROOF/PROOF_Test_User/regulated_data_slurm_account

--- a/.github/workflows/api-tests-regulated.yml
+++ b/.github/workflows/api-tests-regulated.yml
@@ -1,0 +1,40 @@
+name: API Tests Regulated
+
+on:
+  workflow_dispatch:
+  # schedule only triggers if this file is on the default branch
+  # and will only run on the default branch
+  schedule:
+    # every Sunday at 3 pm (8 am PT)
+    - cron: "0 15 * * 0"
+
+jobs:
+  api-tests-regulated:
+    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.7.21"
+          python-version: 3.13.5
+
+      - name: Install
+        run: uv sync --all-extras
+
+      - name: Load secrets
+        uses: 1password/load-secrets-action@v2
+        with:
+          # Export loaded secrets as environment variables to subsequent steps
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          PROOF_API_TOKEN_DEV: "op://PROOF/PROOF_Test_User/dev token"
+          PATH_ROOTS: "op://PROOF/PROOF_PATH_ROOTS/credential"
+          REGULATED_DATA: "op://PROOF/PROOF_Test_User/regulated_data"
+          SLURM_ACCOUNT: "op://PROOF/PROOF_Test_User/regulated_data_slurm_account"
+
+      - name: Run tests
+        run: make test_api_rewrite

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ test_api_rewrite: check_env_vars
 	tests/cromwellapi/
 
 test_api_rewrite_json_report: check_env_vars
+	PROOF_USE_REGULATED_DATA=true PROOF_SLURM_ACCOUNT=testpi_t \
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \
 	--color=yes --record-mode=rewrite --verbose \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ test_api_rewrite: check_env_vars
 	tests/cromwellapi/
 
 test_api_rewrite_json_report: check_env_vars
-	PROOF_USE_REGULATED_DATA=true PROOF_SLURM_ACCOUNT=testpi_t \
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \
 	--color=yes --record-mode=rewrite --verbose \

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,9 @@ regulated-data-envs:
 	op inject -i .env-regulated > .env-temp
 
 test_api_regulated: check_env_vars regulated-data-envs
-	op run -- uv run pytest -n $(WORKERS) \
-	--color=yes --record-mode=once --verbose \
+	op run -- uv run --env-file .env-temp \
+	pytest -n $(WORKERS) \
+	--color=yes --record-mode=rewrite --verbose \
 	tests/cromwellapi/ && \
 	rm .env-temp
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,15 @@ test_api_rewrite: check_env_vars
 	--color=yes --record-mode=rewrite --verbose \
 	tests/cromwellapi/
 
+regulated-data-envs:
+	op inject -i .env-regulated > .env-temp
+
+test_api_regulated: check_env_vars regulated-data-envs
+	op run -- uv run pytest -n $(WORKERS) \
+	--color=yes --record-mode=once --verbose \
+	tests/cromwellapi/ && \
+	rm .env-temp
+
 test_api_rewrite_json_report: check_env_vars
 	op run -- uv run pytest -n $(WORKERS) \
 	--json-report --json-report-file=results.json \

--- a/tests/cromwellapi/conftest.py
+++ b/tests/cromwellapi/conftest.py
@@ -14,18 +14,6 @@ from .utils_cassettes import cassettes_last_modified
 warnings.filterwarnings("error", category=DeprecationWarning)
 
 
-def pytest_report_header(config):
-    mode = config.getoption("--record-mode", default=None)
-    last_mod = cassettes_last_modified("tests/cromwellapi/cassettes")
-    retry_messages_warn = (
-        "" if mode == "rewrite" else "(ignore Retry attempt messages)"
-    )
-    return [
-        f"vcr recording mode: {mode} {retry_messages_warn}",
-        f"vcr cassettes last recorded approx.: {last_mod}",
-    ]
-
-
 @pytest.fixture(scope="session")
 def recording_mode(request):
     return request.config.getoption("--record-mode", default=None)
@@ -53,6 +41,25 @@ def cromwell_api_final(proof_api, recording_mode):
     return CromwellApiFinal(
         url=cromwell_url, recording_mode=recording_mode, sleep=SLEEP_FINAL_STATE
     )
+
+
+def pytest_report_header(config):
+    mode = config.getoption("--record-mode", default=None)
+    last_mod = cassettes_last_modified("tests/cromwellapi/cassettes")
+    retry_messages_warn = (
+        "" if mode == "rewrite" else "(ignore Retry attempt messages)"
+    )
+
+    # Get regulated_data directly from environment variable
+    from .constants import REGULATED_DATA
+
+    regulated_data = bool(REGULATED_DATA) if REGULATED_DATA else False
+
+    return [
+        f"vcr recording mode: {mode} {retry_messages_warn}",
+        f"vcr cassettes last recorded approx.: {last_mod}",
+        f"Asking for Cromwell server w/ regulated data?: {regulated_data}",
+    ]
 
 
 class EnvironmentVariableError(Exception):

--- a/tests/cromwellapi/conftest.py
+++ b/tests/cromwellapi/conftest.py
@@ -36,7 +36,11 @@ def proof_api(recording_mode):
     if recording_mode != "rewrite":
         return MockProofApi()
     else:
-        return ProofApi()
+        slurm_account = os.getenv("PROOF_SLURM_ACCOUNT", "")
+        regulated_data = bool(os.getenv("PROOF_USE_REGULATED_DATA"))
+        return ProofApi(
+            slurm_account=slurm_account, regulated_data=regulated_data
+        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/cromwellapi/conftest.py
+++ b/tests/cromwellapi/conftest.py
@@ -36,11 +36,7 @@ def proof_api(recording_mode):
     if recording_mode != "rewrite":
         return MockProofApi()
     else:
-        slurm_account = os.getenv("PROOF_SLURM_ACCOUNT", "")
-        regulated_data = bool(os.getenv("PROOF_USE_REGULATED_DATA"))
-        return ProofApi(
-            slurm_account=slurm_account, regulated_data=regulated_data
-        )
+        return ProofApi()
 
 
 @pytest.fixture(scope="session")

--- a/tests/cromwellapi/constants.py
+++ b/tests/cromwellapi/constants.py
@@ -3,3 +3,5 @@ import os
 SLEEP_FINAL_STATE = 5
 PROOF_BASE_URL = "https://proof-api-dev.fredhutch.org"
 TOKEN = os.getenv("PROOF_API_TOKEN_DEV")
+REGULATED_DATA = os.getenv("PROOF_REGULATED_DATA")
+SLURM_ACCOUNT = os.getenv("PROOF_SLURM_ACCOUNT")

--- a/tests/cromwellapi/proof.py
+++ b/tests/cromwellapi/proof.py
@@ -43,10 +43,12 @@ def cache_next_call_only(func):
 class ProofApi(object):
     """ProofApi class"""
 
-    def __init__(self):
+    def __init__(self, slurm_account: str = "", regulated_data: bool = False):
         self.base_url = PROOF_BASE_URL
         self.token = token_check(TOKEN)
         self.headers = {"Authorization": f"Bearer {TOKEN}"}
+        self.slurm_account = slurm_account
+        self.regulated_data = regulated_data
 
     @cache_next_call_only
     @retry(
@@ -82,7 +84,10 @@ class ProofApi(object):
             f"{self.base_url}/cromwell-server",
             headers=self.headers,
             timeout=timeout,
-            json={"slurm_account": None},
+            json={
+                "slurm_account": self.slurm_account,
+                "regulated_data": self.regulated_data,
+            },
         )
         res.raise_for_status()
         return res

--- a/tests/cromwellapi/proof.py
+++ b/tests/cromwellapi/proof.py
@@ -47,8 +47,8 @@ class ProofApi(object):
         self.base_url = PROOF_BASE_URL
         self.token = token_check(TOKEN)
         self.headers = {"Authorization": f"Bearer {TOKEN}"}
-        self.slurm_account = slurm_account
-        self.regulated_data = regulated_data
+        self.slurm_account = "testpi_t"
+        self.regulated_data = True
 
     @cache_next_call_only
     @retry(

--- a/tests/cromwellapi/proof.py
+++ b/tests/cromwellapi/proof.py
@@ -6,7 +6,7 @@ from tenacity import (
     wait_exponential,
 )
 
-from .constants import PROOF_BASE_URL, TOKEN
+from .constants import PROOF_BASE_URL, REGULATED_DATA, SLURM_ACCOUNT, TOKEN
 from .utils import before_sleep_message, token_check
 
 
@@ -47,8 +47,10 @@ class ProofApi(object):
         self.base_url = PROOF_BASE_URL
         self.token = token_check(TOKEN)
         self.headers = {"Authorization": f"Bearer {TOKEN}"}
-        self.slurm_account = "testpi_t"
-        self.regulated_data = True
+        self.slurm_account = SLURM_ACCOUNT if SLURM_ACCOUNT else slurm_account
+        self.regulated_data = (
+            REGULATED_DATA if REGULATED_DATA else regulated_data
+        )
 
     @cache_next_call_only
     @retry(

--- a/tests/cromwellapi/proof.py
+++ b/tests/cromwellapi/proof.py
@@ -48,7 +48,7 @@ class ProofApi(object):
         self.token = token_check(TOKEN)
         self.headers = {"Authorization": f"Bearer {TOKEN}"}
         self.slurm_account = SLURM_ACCOUNT if SLURM_ACCOUNT else slurm_account
-        self.regulated_data = (
+        self.regulated_data = bool(
             REGULATED_DATA if REGULATED_DATA else regulated_data
         )
 

--- a/tests/cromwellapi/test-regulated_paths.py
+++ b/tests/cromwellapi/test-regulated_paths.py
@@ -1,0 +1,33 @@
+import os
+import re
+
+import pytest
+
+
+@pytest.mark.vcr
+def test_regulated_paths(proof_api):
+    """
+    Test the Cromwell version endpoint (/engine/v1/version)
+
+    We're not testing exact version number as we just care about the data type
+
+    Args:
+        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
+    """
+    if not hasattr(proof_api, "regulated_data"):
+        pytest.skip("Regulated data not enabled")
+
+    if not proof_api.regulated_data:
+        pytest.skip("Regulated data not enabled")
+
+    path_roots = os.getenv("PATH_ROOTS")
+
+    if not path_roots:
+        pytest.skip("PATH_ROOTS not set")
+
+    prefix = list(
+        filter(None, [re.search(".+ula.+", w) for w in path_roots.split(",")])
+    )[0].string
+
+    status = proof_api.status()
+    assert status["jobInfo"]["SCRATCHDIR"].startswith(prefix)

--- a/tests/cromwellapi/test-regulated_paths.py
+++ b/tests/cromwellapi/test-regulated_paths.py
@@ -7,12 +7,11 @@ import pytest
 @pytest.mark.vcr
 def test_regulated_paths(proof_api):
     """
-    Test the Cromwell version endpoint (/engine/v1/version)
-
-    We're not testing exact version number as we just care about the data type
+    Test that the scratch directory is within the regulated data path
+    when using a regulated data Cromwell server
 
     Args:
-        cromwell_api (CromwellApi): Cromwell server being used to submit WDL unit tests (class defined in cromwell.py)
+        proof_api (ProofApi): ProofApi instance from proof.py
     """
     if not hasattr(proof_api, "regulated_data"):
         pytest.skip("Regulated data not enabled")


### PR DESCRIPTION
fix #185 

- Add new test file for reg data scratch dir path. Sean and I were trying to think of any reg data specific tests, this was the only one so far
- new gh action for running reg data tests 1x a week
- modify proof.py to use env vars for reg data boolean and slurm account string
