### PR TITLE
manually swap between regulated and non-regulated server types

### DIFF
--- a/.github/workflows/api-rewrite-cassettes.yml
+++ b/.github/workflows/api-rewrite-cassettes.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Run tests and process changes
         id: process-changes
         run: |
+          make server_type_not_regulated
+
           make test_api_rewrite_json_report || true
 
           # Check if results.json exists and has valid content

--- a/.github/workflows/api-tests-changed.yml
+++ b/.github/workflows/api-tests-changed.yml
@@ -66,4 +66,5 @@ jobs:
 
       - name: Run tests
         run: |
+          make server_type_not_regulated
           op run -- uv run pytest -n 24 --color=yes --record-mode=rewrite --verbose -s tests/cromwellapi/ -k ${{ matrix.wdl }}

--- a/.github/workflows/api-tests-regulated.yml
+++ b/.github/workflows/api-tests-regulated.yml
@@ -37,4 +37,5 @@ jobs:
           PROOF_SLURM_ACCOUNT: "op://PROOF/PROOF_Test_User/regulated_data_slurm_account"
 
       - name: Run tests
-        run: make test_api_regulated
+        run: |
+          make server_type_regulated && make test_api_regulated

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ check_env_vars:
 check_wdl_dirs:
 	@uv run tests/validate_wdls.py
 
+server_status:
+	op run --no-masking -- uv run python -m tests.cromwellapi.server_type --check-status
+
 server_type_regulated:
 	op run --no-masking -- uv run python -m tests.cromwellapi.server_type --regulated
 

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ check_env_vars:
 check_wdl_dirs:
 	@uv run tests/validate_wdls.py
 
+server_type_regulated:
+	op run -- uv run python -m tests.cromwellapi.server_type --regulated
+
+server_type_not_regulated:
+	op run -- uv run python -m tests.cromwellapi.server_type --not-regulated
+
 test_api_cached: check_env_vars check_wdl_dirs
 	@op run -- uv run pytest -n $(WORKERS) \
 	--color=yes --record-mode=once --verbose \

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ check_wdl_dirs:
 	@uv run tests/validate_wdls.py
 
 server_type_regulated:
-	op run -- uv run python -m tests.cromwellapi.server_type --regulated
+	op run --no-masking -- uv run python -m tests.cromwellapi.server_type --regulated
 
 server_type_not_regulated:
-	op run -- uv run python -m tests.cromwellapi.server_type --not-regulated
+	op run --no-masking -- uv run python -m tests.cromwellapi.server_type --not-regulated
 
 test_api_cached: check_env_vars check_wdl_dirs
 	@op run -- uv run pytest -n $(WORKERS) \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "pytest-xdist>=3.6.1",
   "pytest-json-report>=1.5.0",
   "rich>=14.0.0",
+  "click>=8.2.1",
 ]
 
 [dependency-groups]

--- a/tests/cromwellapi/server_type.py
+++ b/tests/cromwellapi/server_type.py
@@ -1,8 +1,40 @@
+import contextlib
+import sys
+
 import click
 
 from .proof import ProofApi
 
 proof_api = ProofApi()
+
+
+@contextlib.contextmanager
+def suppress_cache_messages():
+    """Context manager to suppress cache-related print statements"""
+    original_stdout = sys.stdout
+
+    class FilteredStdout:
+        def __init__(self, original):
+            self.original = original
+
+        def write(self, text):
+            if text.strip() not in [
+                "result not in cache",
+                "result in cache, returning it",
+            ]:
+                self.original.write(text)
+
+        def flush(self):
+            self.original.flush()
+
+        def __getattr__(self, name):
+            return getattr(self.original, name)
+
+    try:
+        sys.stdout = FilteredStdout(original_stdout)
+        yield
+    finally:
+        sys.stdout = original_stdout
 
 
 @click.command()
@@ -18,63 +50,64 @@ proof_api = ProofApi()
 @click.pass_context
 def server_type(ctx, regulated, check_status):
     """Run a PROOF Cromwell server in regulated or unregulated mode"""
-    cromwell_server_is_up = proof_api.is_cromwell_server_up()
+    with suppress_cache_messages():
+        cromwell_server_is_up = proof_api.is_cromwell_server_up()
 
-    if check_status:
-        if cromwell_server_is_up:
-            click.echo("Cromwell server is up")
-        else:
-            click.echo("Cromwell server is down")
-
-        click.echo(
-            f"regulated data: {proof_api.status()['jobInfo']['USE_REGULATED_DATA']}"
-        )
-        ctx.exit(0)
-
-    if regulated:
-        click.echo("Running server in regulated mode")
-        proof_api.regulated_data = True
-        if cromwell_server_is_up:
-            click.echo("Cromwell server is up")
-            if proof_api.status()["jobInfo"]["USE_REGULATED_DATA"]:
-                click.echo("Regulated data is enabled, let's do this!")
-                ctx.exit(0)
+        if check_status:
+            if cromwell_server_is_up:
+                click.echo(click.style("Cromwell server is up", fg="green"))
             else:
-                click.echo(
-                    "Regulated data is disabled; stopping then starting as regulated"
-                )
-                proof_api.stop()
-                proof_api.wait_for_stopped()
+                click.echo(click.style("Cromwell server is down", fg="red"))
+
+            click.echo(
+                f"regulated data: {click.style(str(proof_api.status()['jobInfo']['USE_REGULATED_DATA']), fg='blue')}"
+            )
+            ctx.exit(0)
+
+        if regulated:
+            click.echo("Running server in regulated mode")
+            proof_api.regulated_data = True
+            if cromwell_server_is_up:
+                click.echo("Cromwell server is up")
+                if proof_api.status()["jobInfo"]["USE_REGULATED_DATA"]:
+                    click.echo("Regulated data is enabled, let's do this!")
+                    ctx.exit(0)
+                else:
+                    click.echo(
+                        "Regulated data is disabled; stopping then starting as regulated"
+                    )
+                    proof_api.stop()
+                    proof_api.wait_for_stopped()
+                    proof_api.start()
+                    proof_api.wait_for_up()
+                    click.echo("Regulated data is enabled, let's do this!")
+            else:
+                click.echo("Cromwell server is down; starting as regulated")
                 proof_api.start()
                 proof_api.wait_for_up()
                 click.echo("Regulated data is enabled, let's do this!")
         else:
-            click.echo("Cromwell server is down; starting as regulated")
-            proof_api.start()
-            proof_api.wait_for_up()
-            click.echo("Regulated data is enabled, let's do this!")
-    else:
-        click.echo("Running server in not-regulated mode")
-        proof_api.regulated_data = False
-        if cromwell_server_is_up:
-            click.echo("Cromwell server is up")
-            if not proof_api.status()["jobInfo"]["USE_REGULATED_DATA"]:
-                click.echo("Regulated data is disabled, let's do this!")
-                ctx.exit(0)
+            click.echo("Running server in not-regulated mode")
+            proof_api.regulated_data = False
+            if cromwell_server_is_up:
+                click.echo("Cromwell server is up")
+                if not proof_api.status()["jobInfo"]["USE_REGULATED_DATA"]:
+                    click.echo("Regulated data is disabled, let's do this!")
+                    ctx.exit(0)
+                else:
+                    click.echo(
+                        "Regulated data is enabled; stopping then starting as not regulated"
+                    )
+                    proof_api.stop()
+                    proof_api.wait_for_stopped()
+                    proof_api.start()
+                    proof_api.wait_for_up()
+                    click.echo("Regulated data is disabled, let's do this!")
             else:
-                click.echo(
-                    "Regulated data is enabled; stopping then starting as not regulated"
-                )
-                proof_api.stop()
-                proof_api.wait_for_stopped()
+                click.echo("Cromwell server is down; starting as not regulated")
                 proof_api.start()
                 proof_api.wait_for_up()
                 click.echo("Regulated data is disabled, let's do this!")
-        else:
-            click.echo("Cromwell server is down; starting as not regulated")
-            proof_api.start()
-            proof_api.wait_for_up()
-            click.echo("Regulated data is disabled, let's do this!")
 
 
 if __name__ == "__main__":

--- a/tests/cromwellapi/server_type.py
+++ b/tests/cromwellapi/server_type.py
@@ -1,11 +1,10 @@
 import contextlib
+import os
 import sys
 
 import click
 
 from .proof import ProofApi
-
-proof_api = ProofApi()
 
 
 @contextlib.contextmanager
@@ -50,7 +49,16 @@ def suppress_cache_messages():
 @click.pass_context
 def server_type(ctx, regulated, check_status):
     """Run a PROOF Cromwell server in regulated or unregulated mode"""
+    op_srv_acct_token = os.getenv("OP_SERVICE_ACCOUNT_TOKEN")
+    if not op_srv_acct_token:
+        click.echo(
+            "OP_SERVICE_ACCOUNT_TOKEN environment variable is not set", err=True
+        )
+        raise click.Abort()
+
     with suppress_cache_messages():
+        proof_api = ProofApi()
+
         cromwell_server_is_up = proof_api.is_cromwell_server_up()
 
         if check_status:

--- a/tests/cromwellapi/server_type.py
+++ b/tests/cromwellapi/server_type.py
@@ -1,0 +1,81 @@
+import click
+
+from .proof import ProofApi
+
+proof_api = ProofApi()
+
+
+@click.command()
+@click.option(
+    "--regulated/--not-regulated",
+    help="Run a PROOF Cromwell server in regulated or unregulated mode",
+)
+@click.option(
+    "--check-status",
+    is_flag=True,
+    help="Check the status of the Cromwell server",
+)
+@click.pass_context
+def server_type(ctx, regulated, check_status):
+    """Run a PROOF Cromwell server in regulated or unregulated mode"""
+    cromwell_server_is_up = proof_api.is_cromwell_server_up()
+
+    if check_status:
+        if cromwell_server_is_up:
+            click.echo("Cromwell server is up")
+        else:
+            click.echo("Cromwell server is down")
+
+        click.echo(
+            f"regulated data: {proof_api.status()['jobInfo']['USE_REGULATED_DATA']}"
+        )
+        ctx.exit(0)
+
+    if regulated:
+        click.echo("Running server in regulated mode")
+        proof_api.regulated_data = True
+        if cromwell_server_is_up:
+            click.echo("Cromwell server is up")
+            if proof_api.status()["jobInfo"]["USE_REGULATED_DATA"]:
+                click.echo("Regulated data is enabled, let's do this!")
+                ctx.exit(0)
+            else:
+                click.echo(
+                    "Regulated data is disabled; stopping then starting as regulated"
+                )
+                proof_api.stop()
+                proof_api.wait_for_stopped()
+                proof_api.start()
+                proof_api.wait_for_up()
+                click.echo("Regulated data is enabled, let's do this!")
+        else:
+            click.echo("Cromwell server is down; starting as regulated")
+            proof_api.start()
+            proof_api.wait_for_up()
+            click.echo("Regulated data is enabled, let's do this!")
+    else:
+        click.echo("Running server in not-regulated mode")
+        proof_api.regulated_data = False
+        if cromwell_server_is_up:
+            click.echo("Cromwell server is up")
+            if not proof_api.status()["jobInfo"]["USE_REGULATED_DATA"]:
+                click.echo("Regulated data is disabled, let's do this!")
+                ctx.exit(0)
+            else:
+                click.echo(
+                    "Regulated data is enabled; stopping then starting as not regulated"
+                )
+                proof_api.stop()
+                proof_api.wait_for_stopped()
+                proof_api.start()
+                proof_api.wait_for_up()
+                click.echo("Regulated data is disabled, let's do this!")
+        else:
+            click.echo("Cromwell server is down; starting as not regulated")
+            proof_api.start()
+            proof_api.wait_for_up()
+            click.echo("Regulated data is disabled, let's do this!")
+
+
+if __name__ == "__main__":
+    server_type()


### PR DESCRIPTION
#185 (issue was already closed)

SO the logic in the `ProofApi` class itself I thought would take care of this but it didn't - and it wasn't totally clear to me why so I'm going with a different approach. 

This route adds a make command via a new script that just handles switching between regulated and non-regulated servers. That's all it does. For this PR this is just added to the regulated server tests yml file, but if it works will add to the other yml file that does test rewrites. 