### PR TITLE
set server back to not regulated after regulated tests run

### DIFF
--- a/.github/workflows/api-tests-regulated.yml
+++ b/.github/workflows/api-tests-regulated.yml
@@ -40,3 +40,7 @@ jobs:
       - name: Run tests
         run: |
           make server_type_regulated && make test_api_regulated
+
+      - name: Back to not regulated
+        run: |
+          make server_type_not_regulated


### PR DESCRIPTION
Will leave server for test user in not regulated state so that when folks log in as the test user they are NOT in a regulated server state (which one should choose to go into rather than be there by default)
