### PR TITLE
Switching from `gpus` to `gpu` in gpuAlloc runtime

### DIFF
--- a/gpuAlloc/README.md
+++ b/gpuAlloc/README.md
@@ -31,11 +31,8 @@ Performs the actual GPU testing and tensor operations.
 4. Captures and formats results
 
 **Runtime Requirements:**
-- GPU: "1" (needs to be a string)
+- GPU: true (boolean)
 - Docker: tensorflow/tensorflow:latest-gpu
-
-## Usage
-Since the `gpus` runtime parameter is specific to PROOF infrastructure, this workflow is best executed on the Fred Hutch HPC using PROOF rather than via the command line directly.
 
 ## Expected Output
 The workflow should produce:

--- a/gpuAlloc/gpuAlloc.wdl
+++ b/gpuAlloc/gpuAlloc.wdl
@@ -69,7 +69,7 @@ task GpuTest {
     runtime {
         docker: "tensorflow/tensorflow:2.11.0-gpu"
         # modules: "TensorFlow/2.11.0-foss-2022a-CUDA-11.7.0"
-        gpus: "1"
+        gpu: true
     }
 
     parameter_meta {


### PR DESCRIPTION
## Summary
- Replace the deprecated `gpus: "1"` string runtime attribute with `gpu: true`, the boolean form used by newer WDL versions
- Update `gpuAlloc/README.md` to reflect the new boolean runtime requirement
- Remove the README's `Usage` section, which called out `gpus` as PROOF-specific, no longer accurate now that `gpu` is the standard key

## Test plan
- [ ] Run the `GpuMatrixMult` workflow via PROOF on Fred Hutch HPC and confirm GPU is still allocated/detected
